### PR TITLE
Add `student grade`, `module grade`, fix compilation issues

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeclareMajorCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeclareMajorCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
-import seedu.address.model.PlannerModelManager;
 import seedu.address.model.person.Person;
 import seedu.address.model.programmes.ComputerScienceProgramme;
 import seedu.address.model.student.Major;

--- a/src/main/java/seedu/address/logic/commands/ModuleAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModuleAddCommand.java
@@ -23,7 +23,7 @@ public class ModuleAddCommand extends ModuleCommand {
 
     public static final String MESSAGE_ADD_MODULE_SUCCESS = "Added module to timetable: %1$s";
     public static final String MESSAGE_ADD_MODULE_ALREADY_EXISTS = "Module is already in timetable: %1$s";
-    public static final String MESSAGE_ADD_MODULE_DOES_NOT_EXISTS = "Module does not exist: %1$s";
+    public static final String MESSAGE_ADD_MODULE_INVALID = "Module code does not exist: %1$s";
 
 
 
@@ -38,7 +38,7 @@ public class ModuleAddCommand extends ModuleCommand {
      * {@code personToEdit}.
      */
     private String generateModuleDoesNotExists(ModuleCode moduleCode) {
-        return String.format(MESSAGE_ADD_MODULE_DOES_NOT_EXISTS, moduleCode.value);
+        return String.format(MESSAGE_ADD_MODULE_INVALID, moduleCode.value);
     }
 
 

--- a/src/main/java/seedu/address/logic/commands/ModuleAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModuleAddCommand.java
@@ -3,8 +3,11 @@ package seedu.address.logic.commands;
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.module.Module;
 import seedu.address.model.module.ModuleCode;
 import seedu.address.model.student.Enrollment;
+
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
@@ -74,11 +77,12 @@ public class ModuleAddCommand extends ModuleCommand {
         }
 
         // Check if module exists in module database
-        if (!model.getPlanner().getModules().contains(moduleCode)) {
+        Module module = model.getPlanner().getModules().getModule(moduleCode);
+        if (module == null) {
             throw new CommandException(generateModuleDoesNotExists(moduleCode));
         }
 
-        Enrollment enrollment = new Enrollment(moduleCode);
+        Enrollment enrollment = new Enrollment(moduleCode, Optional.empty(), module.getModuleCredit());
         model.addEnrollment(enrollment);
         return new CommandResult(generateSuccessMessage(moduleCode));
     }

--- a/src/main/java/seedu/address/logic/commands/ModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModuleCommand.java
@@ -9,6 +9,6 @@ public abstract class ModuleCommand extends Command {
             //+ ": Deletes the person identified by the index number used in the displayed person list.\n"
             //+ "Parameters: INDEX (must be a positive integer)\n"
             + ":\n"
-            + "Subcommands: add, remove, list, list exempted\n"
+            + "Subcommands: add, remove, list, grade\n"
             + "Example: " + COMMAND_WORD + " add CS2030";
 }

--- a/src/main/java/seedu/address/logic/commands/ModuleGradeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModuleGradeCommand.java
@@ -1,0 +1,112 @@
+package seedu.address.logic.commands;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.grades.Grade;
+import seedu.address.model.grades.LetterGrade;
+import seedu.address.model.module.Module;
+import seedu.address.model.module.ModuleCode;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.*;
+
+public class ModuleGradeCommand extends ModuleCommand {
+    public static final String COMMAND_WORD = "grade";
+
+    public static final String MESSAGE_NOT_IMPLEMENTED_YET = "'module grade' command not implemented yet";
+
+    public static final String MESSAGE_USAGE = "module " + COMMAND_WORD
+            + ": If GRADE is specified, sets the grade of the module specified.\n"
+            + "Otherwise, displays grade of module specified.\n"
+            + "Parameters: "
+            + "Module code "
+            + "[" + PREFIX_GRADE + " + GRADE]\n"
+            + "Example: " + "module " + COMMAND_WORD + "CS2030 grade/A";
+
+    public static final String MESSAGE_SET_GRADE_SUCCESS = "Set grade of module %1$s to: %2$s";
+    public static final String MESSAGE_VIEW_GRADE_SUCCESS  = "Grade of module %1$s: %2$s";
+    public static final String MESSAGE_MODULE_INVALID = "Module code does not exist: %1$s";
+    public static final String MESSAGE_MODULE_NOT_ENROLLED = "Module not in selected timetable: %1$s";
+
+
+    private final ModuleCode moduleCode;
+    private final LetterGrade letterGrade;
+    private final boolean isWrite;
+
+    public ModuleGradeCommand(ModuleCode moduleCode, LetterGrade grade) {
+        requireAllNonNull(moduleCode, grade);
+        this.moduleCode = moduleCode;
+        this.letterGrade = grade;
+        this.isWrite = true;
+    }
+
+    public ModuleGradeCommand(ModuleCode moduleCode) {
+        requireAllNonNull(moduleCode);
+        this.moduleCode = moduleCode;
+        this.letterGrade = null;
+        this.isWrite = false;
+    }
+
+    /**
+     * Generates a command execution success message based on whether the remark is added to or removed from
+     * {@code personToEdit}.
+     */
+    private String generateModuleInvalidMessage(ModuleCode moduleCode) {
+        return String.format(MESSAGE_MODULE_INVALID, moduleCode.value);
+    }
+
+
+    /**
+     * Generates a command execution success message based on whether the remark is added to or removed from
+     * {@code personToEdit}.
+     */
+    private String generateModuleNotEnrolledMessage(ModuleCode moduleCode) {
+        return String.format(MESSAGE_MODULE_NOT_ENROLLED, moduleCode.value);
+    }
+
+    private String generateViewGradeSuccessMessage(ModuleCode moduleCode, LetterGrade grade) {
+        return String.format(MESSAGE_VIEW_GRADE_SUCCESS, moduleCode.value, grade);
+    }
+
+    /**
+     * Generates a command execution success message based on whether the remark is added to or removed from
+     * {@code personToEdit}.
+     */
+    private String generateSetGradeSuccessMessage(ModuleCode moduleCode, LetterGrade grade) {
+        return String.format(MESSAGE_SET_GRADE_SUCCESS, moduleCode.value, grade);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        // Check if active student and timetable exists
+        if (model.getActiveStudent() == null) {
+            throw new CommandException(Messages.MESSAGE_NO_STUDENT_ACTIVE);
+        }
+        if (model.getActiveTimeTable() == null) {
+            throw new CommandException(Messages.MESSAGE_NO_TIMETABLE_ACTIVE);
+        }
+
+        // Check if module exists in module database
+        Module module = model.getPlanner().getModules().getModule(moduleCode);
+        if (module == null) {
+            throw new CommandException(generateModuleInvalidMessage(moduleCode));
+        }
+
+        // Check if module is duplicate in active timetable
+        // TODO: have an option to check globally (across all timetables) to prevent duplicate enrollments
+        if (!model.hasEnrollment(moduleCode)) {
+            throw new CommandException(generateModuleNotEnrolledMessage(moduleCode));
+        }
+
+        if (isWrite) {
+            model.setModuleGrade(moduleCode, new Grade(letterGrade, false));
+            return new CommandResult(generateSetGradeSuccessMessage(moduleCode, letterGrade));
+        } else {
+            return new CommandResult(MESSAGE_NOT_IMPLEMENTED_YET);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ModuleGradeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModuleGradeCommand.java
@@ -8,6 +8,8 @@ import seedu.address.model.grades.LetterGrade;
 import seedu.address.model.module.Module;
 import seedu.address.model.module.ModuleCode;
 
+import java.util.Optional;
+
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.*;
@@ -21,9 +23,9 @@ public class ModuleGradeCommand extends ModuleCommand {
             + ": If GRADE is specified, sets the grade of the module specified.\n"
             + "Otherwise, displays grade of module specified.\n"
             + "Parameters: "
-            + "Module code "
-            + "[" + PREFIX_GRADE + " + GRADE]\n"
-            + "Example: " + "module " + COMMAND_WORD + "CS2030 grade/A";
+            + "MODULE_CODE "
+            + "[" + PREFIX_GRADE + "GRADE]\n"
+            + "Example: " + "module " + COMMAND_WORD + " CS2030 grade/A";
 
     public static final String MESSAGE_SET_GRADE_SUCCESS = "Set grade of module %1$s to: %2$s";
     public static final String MESSAGE_VIEW_GRADE_SUCCESS  = "Grade of module %1$s: %2$s";
@@ -66,7 +68,11 @@ public class ModuleGradeCommand extends ModuleCommand {
         return String.format(MESSAGE_MODULE_NOT_ENROLLED, moduleCode.value);
     }
 
-    private String generateViewGradeSuccessMessage(ModuleCode moduleCode, LetterGrade grade) {
+    private String generateViewGradeSuccessMessage(ModuleCode moduleCode) {
+        return String.format(MESSAGE_VIEW_GRADE_SUCCESS, moduleCode.value, "Pending");
+    }
+
+    private String generateViewGradeSuccessMessage(ModuleCode moduleCode, Grade grade) {
         return String.format(MESSAGE_VIEW_GRADE_SUCCESS, moduleCode.value, grade);
     }
 
@@ -106,7 +112,12 @@ public class ModuleGradeCommand extends ModuleCommand {
             model.setModuleGrade(moduleCode, new Grade(letterGrade, false));
             return new CommandResult(generateSetGradeSuccessMessage(moduleCode, letterGrade));
         } else {
-            return new CommandResult(MESSAGE_NOT_IMPLEMENTED_YET);
+            Optional<Grade> optionalGrade = model.getModuleGrade(moduleCode);
+            if (optionalGrade.isPresent()) {
+                return new CommandResult(generateViewGradeSuccessMessage(moduleCode, optionalGrade.get()));
+            } else {
+                return new CommandResult(generateViewGradeSuccessMessage(moduleCode));
+            }
         }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/StudentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StudentCommand.java
@@ -9,6 +9,6 @@ public abstract class StudentCommand extends Command {
             //+ ": Deletes the person identified by the index number used in the displayed person list.\n"
             //+ "Parameters: INDEX (must be a positive integer)\n"
             + ":\n"
-            + "Subcommands: add remove active\n"
+            + "Subcommands: add, remove, active, grade\n"
             + "Example: " + COMMAND_WORD + " active 1";
 }

--- a/src/main/java/seedu/address/logic/commands/StudentGradeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StudentGradeCommand.java
@@ -1,0 +1,53 @@
+package seedu.address.logic.commands;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.grades.CumulativeGrade;
+import seedu.address.model.student.Student;
+
+import java.util.OptionalDouble;
+
+import static java.util.Objects.requireNonNull;
+
+public class StudentGradeCommand extends StudentCommand {
+    public static final String COMMAND_WORD = "grade";
+
+    public static final String MESSAGE_NOT_IMPLEMENTED_YET = "'student grade' command not implemented yet";
+
+    public static final String MESSAGE_USAGE = "student " + COMMAND_WORD
+            + ": Display average grade of active student.\n"
+            + "Example: " + "student " + COMMAND_WORD;
+
+    public static final String MESSAGE_SUCCESS = "Grade of active student %1$s: %2$s\n"
+            + "Enrolled in %3$d MCs total, %4$d MCs are graded, %5$d MCs are declared S/U.";
+
+    /**
+     * Generates a command execution success message based on whether the remark is added to or removed from
+     * {@code personToEdit}.
+     */
+    private String generateSuccessMessage(Student activeStudent, CumulativeGrade cumulativeGrade) {
+        OptionalDouble gradeValue = cumulativeGrade.getAverage();
+        return String.format(MESSAGE_SUCCESS,
+                activeStudent,
+                gradeValue.isPresent() ? String.format("%.2f/5.00", gradeValue.getAsDouble()) : "-/5.00",
+                cumulativeGrade.getTotalCredits(),
+                cumulativeGrade.getTotalGradedCredits(),
+                cumulativeGrade.getTotalSuCredits());
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        // Check if active student and timetable exists
+        if (model.getActiveStudent() == null) {
+            throw new CommandException(Messages.MESSAGE_NO_STUDENT_ACTIVE);
+        }
+
+        Student activeStudent = model.getActiveStudent();
+        CumulativeGrade cumulativeGrade = activeStudent.getCumulativeGrade();
+        return new CommandResult(generateSuccessMessage(activeStudent, cumulativeGrade));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/StudentGradeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StudentGradeCommand.java
@@ -5,8 +5,14 @@ import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.grades.CumulativeGrade;
+import seedu.address.model.grades.Grade;
+import seedu.address.model.student.Enrollment;
 import seedu.address.model.student.Student;
+import seedu.address.model.student.TimeTable;
+import seedu.address.model.time.StudentSemester;
 
+import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalDouble;
 
 import static java.util.Objects.requireNonNull;
@@ -21,7 +27,8 @@ public class StudentGradeCommand extends StudentCommand {
             + "Example: " + "student " + COMMAND_WORD;
 
     public static final String MESSAGE_SUCCESS = "Grade of active student %1$s: %2$s\n"
-            + "Enrolled in %3$d MCs total, %4$d MCs are graded, %5$d MCs are declared S/U.";
+            + "Enrolled in %3$d MCs total, %4$d MCs are graded, %5$d MCs are declared S/U.\n"
+            + "Grade for each module:\n%6$s";
 
     /**
      * Generates a command execution success message based on whether the remark is added to or removed from
@@ -29,12 +36,39 @@ public class StudentGradeCommand extends StudentCommand {
      */
     private String generateSuccessMessage(Student activeStudent, CumulativeGrade cumulativeGrade) {
         OptionalDouble gradeValue = cumulativeGrade.getAverage();
+
+        StringBuffer sb = new StringBuffer();
+
+        for (Map.Entry<StudentSemester, TimeTable> entry : activeStudent.getTimeTableMap().entrySet()) {
+            StudentSemester sem = entry.getKey();
+            TimeTable timeTable = entry.getValue();
+
+            sb.append("\n");
+            sb.append(sem.toString());
+
+            for (Enrollment enrollment : timeTable.enrollments) {
+                sb.append("\n");
+                sb.append(enrollment.getModuleCode().value);
+                sb.append(String.format(" (%d MCs): ", enrollment.credit));
+
+                Optional<Grade> optionalGrade = enrollment.getGrade();
+                if (optionalGrade.isPresent()) {
+                    sb.append(optionalGrade.get().toString());
+                } else {
+                    sb.append("Pending");
+                }
+            }
+
+            sb.append("\n");
+        }
+
         return String.format(MESSAGE_SUCCESS,
                 activeStudent,
                 gradeValue.isPresent() ? String.format("%.2f/5.00", gradeValue.getAsDouble()) : "-/5.00",
                 cumulativeGrade.getTotalCredits(),
                 cumulativeGrade.getTotalGradedCredits(),
-                cumulativeGrade.getTotalSuCredits());
+                cumulativeGrade.getTotalSuCredits(),
+                sb.toString());
     }
 
     @Override
@@ -48,6 +82,7 @@ public class StudentGradeCommand extends StudentCommand {
 
         Student activeStudent = model.getActiveStudent();
         CumulativeGrade cumulativeGrade = activeStudent.getCumulativeGrade();
+
         return new CommandResult(generateSuccessMessage(activeStudent, cumulativeGrade));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -12,6 +12,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
 
+    public static final Prefix PREFIX_GRADE = new Prefix("grade/");
     public static final Prefix PREFIX_MAJOR = new Prefix("major/");
     public static final Prefix PREFIX_MINOR = new Prefix("minor/");
     public static final Prefix PREFIX_STUDENT_YEAR  = new Prefix("year/");

--- a/src/main/java/seedu/address/logic/parser/ModuleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ModuleCommandParser.java
@@ -42,6 +42,9 @@ public class ModuleCommandParser implements Parser<ModuleCommand> {
         case ModuleListCommand.COMMAND_WORD:
             return new ModuleListCommand();
 
+        case ModuleGradeCommand.COMMAND_WORD:
+            return new ModuleGradeCommandParser().parse(arguments);
+
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }

--- a/src/main/java/seedu/address/logic/parser/ModuleGradeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ModuleGradeCommandParser.java
@@ -1,0 +1,62 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.ModuleAddCommand;
+import seedu.address.logic.commands.ModuleGradeCommand;
+import seedu.address.logic.commands.StudentAddCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.grades.LetterGrade;
+import seedu.address.model.module.ModuleCode;
+
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.*;
+
+public class ModuleGradeCommandParser implements Parser<ModuleGradeCommand> {
+    public static final String MESSAGE_GRADE_INVALID = "Grade is invalid: %1$s";
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeclareMajorCommand
+     * and returns a DeclareMajorCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    @Override
+    public ModuleGradeCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+
+        //NOTE: the concatenation " " is a workaround for `ArgumentTokenizer` treating the first argument as the preamble
+        //TODO: use ArgumentTokenizer for all subcommands
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(" " + args, PREFIX_GRADE);
+
+        if (argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModuleGradeCommand.MESSAGE_USAGE));
+        }
+
+        try {
+            ModuleCode moduleCode = new ModuleCode(argMultimap.getPreamble());
+
+            if (arePrefixesPresent(argMultimap, PREFIX_GRADE)) {
+                String letterGradeString = argMultimap.getValue(PREFIX_GRADE).get();
+                try {
+                    LetterGrade letterGrade = LetterGrade.valueOf(letterGradeString);
+                    return new ModuleGradeCommand(moduleCode, letterGrade);
+                } catch (IllegalArgumentException e) {
+                    throw new ParseException(String.format(MESSAGE_GRADE_INVALID, letterGradeString));
+                }
+            } else {
+                return new ModuleGradeCommand(moduleCode);
+            }
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(e.getMessage());
+        }
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/StudentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/StudentCommandParser.java
@@ -45,6 +45,9 @@ public class StudentCommandParser implements Parser<StudentCommand> {
         case StudentListCommand.COMMAND_WORD:
             return new StudentListCommand();
 
+        case StudentGradeCommand.COMMAND_WORD:
+            return new StudentGradeCommand();
+
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,13 +1,12 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
-import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.grades.Grade;
-import seedu.address.model.module.Module;
 import seedu.address.model.module.ModuleCode;
 import seedu.address.model.person.Person;
 import seedu.address.model.student.Enrollment;
@@ -127,6 +126,8 @@ public interface Model {
     void addSemesterTimeTable(StudentSemester studentSemester);
 
     void removeSemesterTimeTable(StudentSemester studentSemester);
+
+    Optional<Grade> getModuleGrade(ModuleCode moduleCode);
 
     void setModuleGrade(ModuleCode moduleCode, Grade grade);
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -6,6 +6,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.grades.Grade;
 import seedu.address.model.module.Module;
 import seedu.address.model.module.ModuleCode;
 import seedu.address.model.person.Person;
@@ -126,4 +127,6 @@ public interface Model {
     void addSemesterTimeTable(StudentSemester studentSemester);
 
     void removeSemesterTimeTable(StudentSemester studentSemester);
+
+    void setModuleGrade(ModuleCode moduleCode, Grade grade);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,6 +11,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.grades.Grade;
 import seedu.address.model.module.ModuleCode;
 import seedu.address.model.person.Person;
 import seedu.address.model.student.Enrollment;
@@ -230,5 +231,9 @@ public class ModelManager implements Model {
 
     public void removeSemesterTimeTable(StudentSemester studentSemester) {
         planner.removeSemesterTimeTable(studentSemester);
+    }
+
+    public void setModuleGrade(ModuleCode moduleCode, Grade grade) {
+        planner.setModuleGrade(moduleCode, grade);
     }
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -231,6 +232,10 @@ public class ModelManager implements Model {
 
     public void removeSemesterTimeTable(StudentSemester studentSemester) {
         planner.removeSemesterTimeTable(studentSemester);
+    }
+
+    public Optional<Grade> getModuleGrade(ModuleCode moduleCode) {
+        return planner.getModuleGrade(moduleCode);
     }
 
     public void setModuleGrade(ModuleCode moduleCode, Grade grade) {

--- a/src/main/java/seedu/address/model/Planner.java
+++ b/src/main/java/seedu/address/model/Planner.java
@@ -6,6 +6,7 @@ import seedu.address.model.module.Module;
 import seedu.address.model.module.*;
 import seedu.address.model.student.*;
 import seedu.address.model.time.StudentSemester;
+import seedu.address.model.util.SampleDataUtil;
 
 import java.util.List;
 
@@ -61,18 +62,6 @@ public class Planner implements ReadOnlyPlanner {
     }
 
 
-    /**
-     * Returns a valid planner state.
-     * @return Sample planner
-     */
-    public static Planner samplePlanner() {
-        Planner planner = new Planner();
-        Student student = new Student(new Name("Mark Suckerberg"), new Major("CS"), TimeTableMap.sampleTimeTableMap());
-        planner.students.add(student);
-        planner.activeStudent = student;
-        return planner;
-    }
-
     public boolean addStudent(Student student) {
         students.add(student);
         return true;
@@ -81,7 +70,6 @@ public class Planner implements ReadOnlyPlanner {
     public boolean resetData(Planner planner) {
         activeStudent = planner.activeStudent;
         students = planner.students;
-        modules = planner.modules;
         return true;
     }
 
@@ -152,7 +140,7 @@ public class Planner implements ReadOnlyPlanner {
 
     /**
      * Replaces the currently active student with the student given by (@code editedStudent).
-     * @params editedStudent Student to copy for replacement
+     * @params editedStudent Student to copy for replacement.
      */
     public void setActiveStudent(Student editedStudent) {
         // TODO: ensure that `activeStudent` is not null
@@ -199,7 +187,7 @@ public class Planner implements ReadOnlyPlanner {
         //TODO: handle `activeStudents` being null (e.g. if data file is missing)
         //TODO: handle all students being removed
         if (activeStudent.getTimeTableMap().isEmpty()) {
-            throw new IllegalArgumentException("Active student has no timetables");
+            throw new IllegalArgumentException("The active student has no timetables");
         }
         activeSemester = activeStudent.getTimeTableMap().keySet().iterator().next();
     }
@@ -245,7 +233,7 @@ public class Planner implements ReadOnlyPlanner {
             throw new IllegalArgumentException("No active student selected");
         }
         if (!hasSemester(studentSemester)) {
-            throw new IllegalArgumentException("Semester does not exists in timetable list");
+            throw new IllegalArgumentException("Semester does not exist in timetable list");
         }
 
         activeStudent.removeTimeTable(studentSemester);

--- a/src/main/java/seedu/address/model/Planner.java
+++ b/src/main/java/seedu/address/model/Planner.java
@@ -105,6 +105,11 @@ public class Planner implements ReadOnlyPlanner {
         //return enrolledModules.contains(moduleCode);
     }
 
+    public Optional<Grade> getModuleGrade(ModuleCode moduleCode) {
+        Enrollment enrollment = getEnrollment(moduleCode);
+        return enrollment.getGrade();
+    }
+
     public void setModuleGrade(ModuleCode moduleCode, Grade grade) {
         Enrollment enrollment = getEnrollment(moduleCode);
         enrollment.grade = Optional.of(grade);

--- a/src/main/java/seedu/address/model/Planner.java
+++ b/src/main/java/seedu/address/model/Planner.java
@@ -2,6 +2,7 @@ package seedu.address.model;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.grades.Grade;
 import seedu.address.model.module.Module;
 import seedu.address.model.module.*;
 import seedu.address.model.student.*;
@@ -9,6 +10,7 @@ import seedu.address.model.time.StudentSemester;
 import seedu.address.model.util.SampleDataUtil;
 
 import java.util.List;
+import java.util.Optional;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
@@ -94,6 +96,18 @@ public class Planner implements ReadOnlyPlanner {
         TimeTable timeTable = getActiveTimeTable();
         return timeTable.hasModuleCode(moduleCode);
         //return enrolledModules.contains(moduleCode);
+    }
+
+    public Enrollment getEnrollment(ModuleCode moduleCode) {
+        requireAllNonNull(moduleCode);
+        TimeTable timeTable = getActiveTimeTable();
+        return timeTable.getEnrollment(moduleCode);
+        //return enrolledModules.contains(moduleCode);
+    }
+
+    public void setModuleGrade(ModuleCode moduleCode, Grade grade) {
+        Enrollment enrollment = getEnrollment(moduleCode);
+        enrollment.grade = Optional.of(grade);
     }
 
     public boolean addEnrollment(Enrollment enrollment) {

--- a/src/main/java/seedu/address/model/ReadOnlyPlanner.java
+++ b/src/main/java/seedu/address/model/ReadOnlyPlanner.java
@@ -1,11 +1,14 @@
 package seedu.address.model;
 
 import javafx.collections.ObservableList;
+import seedu.address.model.grades.Grade;
 import seedu.address.model.module.Module;
 import seedu.address.model.module.ModuleCode;
 import seedu.address.model.module.UniqueModuleList;
 import seedu.address.model.student.Student;
 import seedu.address.model.time.StudentSemester;
+
+import java.util.Optional;
 
 /**
  * Unmodifiable view of an address book
@@ -28,4 +31,6 @@ public interface ReadOnlyPlanner {
     ObservableList<ModuleCode> getActiveModuleCodes();
 
     boolean hasSemester(StudentSemester semester);
+
+    Optional<Grade> getModuleGrade(ModuleCode moduleCode);
 }

--- a/src/main/java/seedu/address/model/grades/CumulativeGrade.java
+++ b/src/main/java/seedu/address/model/grades/CumulativeGrade.java
@@ -4,16 +4,70 @@ import java.util.OptionalDouble;
 
 public class CumulativeGrade {
     protected int numSu;
-    protected double totalGradePoints;
     protected int totalCredits;
+    protected double totalGradePoints;
+    protected int totalGradedCredits;
+    protected int totalSuCredits;
 
-    public CumulativeGrade(int numSu, double totalGradePoints, int totalCredits) {
+    public CumulativeGrade(int numSu, int totalCredits, double totalGradePoints, int totalGradedCredits, int totalSuCredits) {
         this.numSu = numSu;
-        this.totalGradePoints = totalGradePoints;
         this.totalCredits = totalCredits;
+        this.totalGradePoints = totalGradePoints;
+        this.totalGradedCredits = totalGradedCredits;
+        this.totalSuCredits = totalSuCredits;
     }
 
-    public OptionalDouble getValue() {
-        return OptionalDouble.empty();
+    public CumulativeGrade() {
+        this(0,0,0,0,0);
+    }
+
+    /**
+     * Accumulates the grade to the counter.
+     * @param isSu Whether the grade is declared S/U
+     * @param gradePoint Weighted grade points, equal to grade point of the grade multiplied by number of credits
+     * @param credits Number of credits
+     */
+    private void accumulate(boolean isSu, double gradePoint, int credits) {
+        totalCredits += credits;
+        if (isSu) {
+            numSu++;
+            totalSuCredits += credits;
+        } else {
+            totalGradePoints += gradePoint;
+            totalGradedCredits += credits;
+        }
+    }
+
+    public void accumulate(Grade grade, int credits) {
+        accumulate(grade.isSu || grade.letterGrade.isSu, grade.getGradePoint().getAsDouble(), credits);
+    }
+
+    /**2
+     * Accumulates pending module credits. This does not affect the calculated CAP.
+     * The number of S/U modules declared is not affected.
+     * @param credits Number of credits
+     */
+    public void accumulate(int credits) {
+        totalCredits += credits;
+    }
+
+    public OptionalDouble getAverage() {
+        if (totalGradedCredits > 0) {
+            return OptionalDouble.of(totalGradePoints / (double) totalGradedCredits);
+        } else {
+            return OptionalDouble.empty();
+        }
+    }
+
+    public int getTotalCredits() {
+        return totalCredits;
+    }
+
+    public int getTotalGradedCredits() {
+        return totalGradedCredits;
+    }
+
+    public Object getTotalSuCredits() {
+        return totalSuCredits;
     }
 }

--- a/src/main/java/seedu/address/model/grades/CumulativeGrade.java
+++ b/src/main/java/seedu/address/model/grades/CumulativeGrade.java
@@ -22,33 +22,41 @@ public class CumulativeGrade {
     }
 
     /**
-     * Accumulates the grade to the counter.
-     * @param isSu Whether the grade is declared S/U
-     * @param gradePoint Weighted grade points, equal to grade point of the grade multiplied by number of credits
+     * Accumulates the letter grade to the counter.
+     * @param gradePoint Grade points, from 0.0 to 5.0
      * @param credits Number of credits
      */
-    private void accumulate(boolean isSu, double gradePoint, int credits) {
+    private void accumulateGraded(double gradePoint, int credits) {
         totalCredits += credits;
-        if (isSu) {
-            numSu++;
-            totalSuCredits += credits;
-        } else {
-            totalGradePoints += gradePoint;
-            totalGradedCredits += credits;
-        }
+        totalGradePoints += gradePoint * credits;
+        totalGradedCredits += credits;
     }
 
-    public void accumulate(Grade grade, int credits) {
-        accumulate(grade.isSu || grade.letterGrade.isSu, grade.getGradePoint().getAsDouble(), credits);
+    /**
+     * Accumulates module credits and the S/U to the counter.
+     * @param credits Number of credits
+     */
+    private void accumulateSu(int credits) {
+        totalCredits += credits;
+        numSu++;
+        totalSuCredits += credits;
     }
 
-    /**2
+    /**
      * Accumulates pending module credits. This does not affect the calculated CAP.
      * The number of S/U modules declared is not affected.
      * @param credits Number of credits
      */
-    public void accumulate(int credits) {
+    public void accumulatePending(int credits) {
         totalCredits += credits;
+    }
+
+    public void accumulate(Grade grade, int credits) {
+        if (grade.isSu || grade.letterGrade.isSu) {
+            accumulateSu(credits);
+        } else {
+            accumulateGraded(grade.getGradePoint().getAsDouble(), credits);
+        }
     }
 
     public OptionalDouble getAverage() {

--- a/src/main/java/seedu/address/model/grades/Grade.java
+++ b/src/main/java/seedu/address/model/grades/Grade.java
@@ -19,4 +19,13 @@ public class Grade {
     public OptionalDouble getGradePoint() {
         return letterGrade.points;
     }
+
+    @Override
+    public String toString() {
+        if (isSu && !letterGrade.isSu) {
+            return String.format("%s (S/U exercised)", this.letterGrade);
+        } else {
+            return String.format("%s", this.letterGrade);
+        }
+    }
 }

--- a/src/main/java/seedu/address/model/grades/Grade.java
+++ b/src/main/java/seedu/address/model/grades/Grade.java
@@ -3,15 +3,20 @@ package seedu.address.model.grades;
 import java.util.OptionalDouble;
 
 public class Grade {
-    protected LetterGrade letterGrade;
-    protected boolean isSu;
+    protected final LetterGrade letterGrade;
+    protected final boolean isSu;
 
     public Grade(LetterGrade letterGrade, boolean isSu) {
         this.letterGrade = letterGrade;
         this.isSu = isSu;
     }
 
-    public OptionalDouble getGradePoint(int credit) {
-        return OptionalDouble.empty();
+    /**
+     * The grade point of the letter grade. This ranges from 0.0 to 5.0.
+     * This does not account the S/U declaration (@code isSu).
+     * @return Grade point of letter grade
+     */
+    public OptionalDouble getGradePoint() {
+        return letterGrade.points;
     }
 }

--- a/src/main/java/seedu/address/model/grades/Grade.java
+++ b/src/main/java/seedu/address/model/grades/Grade.java
@@ -3,8 +3,8 @@ package seedu.address.model.grades;
 import java.util.OptionalDouble;
 
 public class Grade {
-    protected final LetterGrade letterGrade;
-    protected final boolean isSu;
+    public final LetterGrade letterGrade;
+    public final boolean isSu;
 
     public Grade(LetterGrade letterGrade, boolean isSu) {
         this.letterGrade = letterGrade;

--- a/src/main/java/seedu/address/model/grades/LetterGrade.java
+++ b/src/main/java/seedu/address/model/grades/LetterGrade.java
@@ -1,5 +1,34 @@
 package seedu.address.model.grades;
 
+import java.util.OptionalDouble;
+
 public enum LetterGrade {
-    A_PLUS, A, A_MINUS, B_PLUS, B, B_MINUS, C_PLUS, C, D_PLUS, D, F, CS, CU, W, EXE
+    A_PLUS(5.0),
+    A(5.0),
+    A_MINUS(4.5),
+    B_PLUS(4.0),
+    B(3.5),
+    B_MINUS(3.0),
+    C_PLUS(2.5),
+    C(2.0),
+    D_PLUS(1.5),
+    D(1.0),
+    F(0.0),
+    CS,
+    CU,
+    W,
+    EXE;
+
+    public final OptionalDouble points;
+    public final boolean isSu;
+
+    LetterGrade(double points) {
+        this.points = OptionalDouble.of(points);
+        this.isSu = false;
+    }
+
+    LetterGrade() {
+        this.points = OptionalDouble.empty();
+        this.isSu = true;
+    }
 }

--- a/src/main/java/seedu/address/model/module/Module.java
+++ b/src/main/java/seedu/address/model/module/Module.java
@@ -59,4 +59,8 @@ public class Module {
         return false; // TODO
     }
 
+    public int getModuleCredit() {
+        //TODO: make `moduleCredit` an `int`
+        return Integer.parseInt(moduleCredit);
+    }
 }

--- a/src/main/java/seedu/address/model/student/Enrollment.java
+++ b/src/main/java/seedu/address/model/student/Enrollment.java
@@ -7,24 +7,31 @@ import seedu.address.model.module.ModuleCode;
 import java.util.Optional;
 import java.util.OptionalDouble;
 
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
 public class Enrollment {
     public ModuleCode code;
     public Optional<Grade> grade;
     public int credit;
 
-    public Enrollment(ModuleCode code) {
+    public Enrollment(ModuleCode code, Optional<Grade> grade, int credit) {
+        requireAllNonNull(code, grade, credit);
         this.code = code;
-        this.grade = Optional.empty();
-        this.credit = 0;
+        this.grade = grade;
+        this.credit = credit;
     }
 
     public ModuleCode getModuleCode() {
         return code;
     }
 
+    public Optional<Grade> getGrade() {
+        return grade;
+    }
+
     public OptionalDouble getGradePoint() {
         if (grade.isPresent()) {
-            return grade.get().getGradePoint(credit);
+            return grade.get().getGradePoint();
         } else {
             return OptionalDouble.empty();
         }

--- a/src/main/java/seedu/address/model/student/Student.java
+++ b/src/main/java/seedu/address/model/student/Student.java
@@ -194,7 +194,7 @@ public class Student {
                 OptionalDouble gradePoint = enrollment.getGradePoint();
                 cumulativeGrade.accumulate(optionalGrade.get(), enrollment.credit);
             } else {
-                cumulativeGrade.accumulate(enrollment.credit);
+                cumulativeGrade.accumulatePending(enrollment.credit);
             }
         }
         return cumulativeGrade;

--- a/src/main/java/seedu/address/model/student/Student.java
+++ b/src/main/java/seedu/address/model/student/Student.java
@@ -3,6 +3,8 @@ package seedu.address.model.student;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.grades.CumulativeGrade;
+import seedu.address.model.grades.Grade;
 import seedu.address.model.graduation.FocusAreaGraduationRequirement;
 import seedu.address.model.graduation.GraduationRequirement;
 import seedu.address.model.module.ModuleCode;
@@ -10,9 +12,7 @@ import seedu.address.model.programmes.DegreeProgramme;
 import seedu.address.model.programmes.specialisations.GenericSpecialisation;
 import seedu.address.model.time.StudentSemester;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
@@ -164,6 +164,14 @@ public class Student {
         return allModules;
     }
 
+    public ObservableList<Enrollment> getAllEnrollments() {
+        ObservableList<Enrollment> allEnrollments = FXCollections.observableArrayList();
+        for (TimeTable timeTable : timeTableMap.values()) {
+            allEnrollments.addAll(timeTable.getEnrollments().asUnmodifiableObservableList());
+        }
+        return allEnrollments;
+    }
+
     public GenericSpecialisation getSpecialisation() {
         return specialisation;
     }
@@ -176,5 +184,19 @@ public class Student {
                 focusAreaGraduationRequirement.setGenericSpecialisation(specialisation);
             }
         }
+    }
+
+    public CumulativeGrade getCumulativeGrade() {
+        CumulativeGrade cumulativeGrade = new CumulativeGrade();
+        for (Enrollment enrollment : getAllEnrollments()) {
+            Optional<Grade> optionalGrade = enrollment.getGrade();
+            if (optionalGrade.isPresent()) {
+                OptionalDouble gradePoint = enrollment.getGradePoint();
+                cumulativeGrade.accumulate(optionalGrade.get(), enrollment.credit);
+            } else {
+                cumulativeGrade.accumulate(enrollment.credit);
+            }
+        }
+        return cumulativeGrade;
     }
 }

--- a/src/main/java/seedu/address/model/student/TimeTable.java
+++ b/src/main/java/seedu/address/model/student/TimeTable.java
@@ -32,6 +32,15 @@ public class TimeTable {
         return enrollments.contains(enrollment);
     }
 
+    public Enrollment getEnrollment(ModuleCode moduleCode) {
+        for (Enrollment enrollment : enrollments) {
+            if (enrollment.getModuleCode().equals(moduleCode)) {
+                return enrollment;
+            }
+        }
+        throw new NullPointerException(String.format("Key %s does not exist", moduleCode));
+    }
+
     public UniqueEnrollmentList getEnrollments() {
         return enrollments;
         //return enrollments.asUnmodifiableObservableList(); //TODO: replace with ObservableList<Enrollment>

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -1,6 +1,7 @@
 package seedu.address.model.util;
 
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -60,7 +61,8 @@ public class SampleDataUtil {
     }
 
     public static Student getSampleStudent() {
-        Student sampleStudent = new Student(new seedu.address.model.student.Name("Placeholder name"), new Major("Placeholder major"), SampleDataUtil.getSampleTimeTableMap());
+        Student sampleStudent = new Student(new seedu.address.model.student.Name("Mark"), new Major("CS"), SampleDataUtil.getSampleTimeTableMap());
+        //Student sampleStudent = new Student(new seedu.address.model.student.Name("Placeholder name"), new Major("Placeholder major"), SampleDataUtil.getSampleTimeTableMap());
         return sampleStudent;
     }
 
@@ -76,7 +78,7 @@ public class SampleDataUtil {
      */
     public static TimeTable getSampleTimeTable() {
         TimeTable timeTable = new TimeTable();
-        timeTable.addEnrollment(new Enrollment(new ModuleCode("CS2040")));
+        timeTable.addEnrollment(new Enrollment(new ModuleCode("CS2040"), Optional.empty(),4));
         return timeTable;
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedEnrollment.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedEnrollment.java
@@ -4,25 +4,38 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.grades.Grade;
 import seedu.address.model.module.Module;
 import seedu.address.model.module.ModuleCode;
 import seedu.address.model.student.Enrollment;
 import seedu.address.model.student.TimeTableMap;
 
+import java.util.Optional;
+
 //TODO: add other fields (currently only stores ModuleCode)
 public class JsonAdaptedEnrollment {
     private final JsonAdaptedModuleCode code;
+    /**
+     * Represents the student's grade. Can be null.
+     */
+    public Grade grade;
+    public int credit;
 
     @JsonCreator
-    public JsonAdaptedEnrollment(@JsonProperty("code") JsonAdaptedModuleCode code) {
+    public JsonAdaptedEnrollment(@JsonProperty("code") JsonAdaptedModuleCode code, @JsonProperty("grade") Grade grade,
+                                 @JsonProperty("credit") int credit) {
         this.code = code;
+        this.grade = grade;
+        this.credit = credit;
     }
 
     public JsonAdaptedEnrollment(Enrollment source) {
         this.code = new JsonAdaptedModuleCode(source.getModuleCode());
+        this.grade = source.getGrade().orElse(null);
+        this.credit = source.credit;
     }
 
     public Enrollment toModelType() throws IllegalValueException  {
-        return new Enrollment(code.toModelType());
+        return new Enrollment(code.toModelType(), Optional.ofNullable(grade), credit);
     }
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedEnrollment.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedEnrollment.java
@@ -18,11 +18,11 @@ public class JsonAdaptedEnrollment {
     /**
      * Represents the student's grade. Can be null.
      */
-    public Grade grade;
+    public JsonAdaptedGrade grade;
     public int credit;
 
     @JsonCreator
-    public JsonAdaptedEnrollment(@JsonProperty("code") JsonAdaptedModuleCode code, @JsonProperty("grade") Grade grade,
+    public JsonAdaptedEnrollment(@JsonProperty("code") JsonAdaptedModuleCode code, @JsonProperty("grade") JsonAdaptedGrade grade,
                                  @JsonProperty("credit") int credit) {
         this.code = code;
         this.grade = grade;
@@ -31,11 +31,16 @@ public class JsonAdaptedEnrollment {
 
     public JsonAdaptedEnrollment(Enrollment source) {
         this.code = new JsonAdaptedModuleCode(source.getModuleCode());
-        this.grade = source.getGrade().orElse(null);
+        Optional<Grade> optionalGrade = source.getGrade();
+        if (optionalGrade.isPresent()) {
+            this.grade = new JsonAdaptedGrade(optionalGrade.get());
+        } else {
+            this.grade = null;
+        }
         this.credit = source.credit;
     }
 
     public Enrollment toModelType() throws IllegalValueException  {
-        return new Enrollment(code.toModelType(), Optional.ofNullable(grade), credit);
+        return new Enrollment(code.toModelType(), grade == null ? Optional.empty() : Optional.of(grade.toModelType()), credit);
     }
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedGrade.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedGrade.java
@@ -1,0 +1,31 @@
+package seedu.address.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.grades.Grade;
+import seedu.address.model.grades.LetterGrade;
+import seedu.address.model.student.Enrollment;
+
+import java.util.Optional;
+
+//TODO: add other fields (currently only stores ModuleCode)
+public class JsonAdaptedGrade {
+    protected final String letterGrade;
+    protected final boolean isSu;
+
+    @JsonCreator
+    public JsonAdaptedGrade(@JsonProperty("letterGrade") String letterGrade, @JsonProperty("isSu") boolean isSu) {
+        this.letterGrade = letterGrade;
+        this.isSu = isSu;
+    }
+
+    public JsonAdaptedGrade(Grade source) {
+        this.letterGrade = source.letterGrade.toString();
+        this.isSu = source.isSu;
+    }
+
+    public Grade toModelType() throws IllegalValueException  {
+        return new Grade(LetterGrade.valueOf(letterGrade), isSu);
+    }
+}


### PR DESCRIPTION
Grades for modules in the currently selected timetable can now be viewed and declared with `module grade`.
The `student grade` command displays the selected student's overall CAP, a summary of the number of graded, SU and total MCs, and the list of modules and their grades.

Minor fixes to the existing code were made to fix issues preventing successful compilation.