### PR TITLE
Fixes to User Guide

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -136,55 +136,42 @@ When you are done using the application, you can exit the program with the `exit
 
 Format: `exit`
 
-=== Declaration Management
+=== Degree Management
 
-The following commands below are part of the application's *Declaration Management*, which allow you to declare important details of your academic plan, such as your `majors`, `minors`, `specialisations` and `tracks`.
+The following commands below are part of the application's *Degree Management*, which allow you to declare important details of your academic plan, such as your `majors` and `specialisations`.
 
 [NOTE]
 All the following commands require a `student` to be selected (using the `student active` command).
 
-==== Declaring your major: `declare major`
+==== Declaring your major: `major set`
 
 You can use this command to declare the `major` of your studies, which is also required for the module planning.
 
-Format: `declare major MAJOR`
+Format: `major set MAJOR`
 
 Examples:
 
-* `declare major comsci`
+* `major set CS`
 
-==== Declaring your minor: `declare minor`
-
-You can use this command to declare any `minors` of your studies, which will affect module planning.
-
-Format: `declare minor MINOR`
-
-Examples:
-
-* `declare minor none`
-* `declare minor comsci`
-
-==== Declaring your specialisation: `declare spec`
+==== Declaring your specialisation: `specialisation set`
 
 You can use this command to declare any `specialisations` in your studies, should you require them in module planning.
 
-Format: `declare spec [ACTION] [SPEC]`
+Format: `specalisation set [SPEC]`
 
 Examples:
 
-* `declare spec add it-security`
-* `declare spec remove it-security`
+* `specialisation set algo`
 
-==== Declaring your track: `declare track`
+==== Viewing your degree progression: `major status`
 
-You can use this command to declare any `tracks` in your studies, should you require them in module planning.
+You can use this command view your degree progression.
 
-Format: `declare track [ACTION] [SPEC]`
+Format: `major status`
 
 Examples:
 
-* `declare track add networking`
-* `declare track remove networking`
+* `major status`
 
 === Grade Management
 
@@ -467,12 +454,11 @@ If you need more in-depth information on a specific command, you can kbd:[CTRL +
 * *Viewing help* : `help`
 * *Exiting the program* : `exit`
 
-=== Declaration Management
+=== Degree Management
 
-* *Declaring your major* : `declare major`
-* *Declaring your minor* : `declare minor`
-* *Declaring your specialisation* : `declare spec`
-* *Declaring your track* : `declare track`
+* *Declaring your major* : `major set`
+* *Declaring your specialisation*: `specialisation set`
+* *Viewing your degree progression* : `major status`
 
 === Grade Management
 

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -66,6 +66,8 @@ Please note the following which may serve as points of interests throughout this
 
 . [underline]#underlined# : This underline indicates clickable links referring to other sections of this *User Guide*. When used in conjunction with a grey highlight (e.g. <<student-active-command,`student active`>>), this indicates a clickable reference to another command.
 
+. **bold** : This bold font indicates sections of this *User Guide*.
+
 [NOTE]
 This symbol and corresponding box has information that you may wish to take note of.
 
@@ -119,6 +121,8 @@ These are parameters that are commonly used in commands available in NUSModPlnr.
 ** Must be one of the following: `ONE`, `TWO`, `SPECIAL_ONE`, `SPECIAL_TWO`
 * `YEAR` - a year number of your degree (e.g. year 1, 2, ...)
 ** Must be a non-negative integer
+* `GRADE` a letter grade for a module
+** Must be one of the following: `A+`, `A`, `A-`, `B+`, `B`, `B-`, `C+`, `C`, `D+`, `D`, `F`, `CS`, `CU`, `W`, `EXE`
 ====
 
 Let's begin!
@@ -142,7 +146,7 @@ Format: `exit`
 [[student-management]]
 === Student Management
 
-The following commands below are part of the application's *Student Management*, which allow you manage the students *which include you* for the academic planning. You are highly encouraged to use this *Student Management* feature to explore different academic plans.
+The following commands below are part of the application's *Student Management*, which allow you manage the students _which include you_ for the academic planning. You are highly encouraged to use this *Student Management* feature to explore different academic plans.
 
 When managing students, you will be able to see the *Student View Screen* (_Figure 3. below_).
 
@@ -287,6 +291,13 @@ All the following commands require a <<student-management,student>> to be select
 
 You can use this command to add a <<timetable-management,timetable>> to the specified <<common-parameter-list,semester>> of the selected <<student-management,student>> (see the <<student-active-command,`student active`>> command).
 
+[NOTE]
+This command requires the `YEAR` and `SEM` to conform to the parameter syntax in <<common-parameter-list,*Common Parameters*>>.
+[TIP]
+While any non-negative degree year for the `YEAR` parameter is allowed (e.g. 0, 1, 999999999), try to use reasonable values for your academic planning.
+[TIP]
+The `YEAR` parameter can take the value of `0`. You can use this to add modules you have taken before entering NUS which you do not want to mark as exempt (using the <<exempt-add-command,`exempt add`>> command).
+
 Format: `timetable add year/YEAR sem/SEM`
 
 Example:
@@ -365,6 +376,7 @@ Example:
 
 * `module list`
 
+[[exempt-add-command]]
 ==== Adding an exempted module: `exempt add`
 
 You can use this command to add an exempted module for the selected <<student-management,student>> (see the <<student-active-command,`student active`>> command).

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -64,6 +64,8 @@ Please note the following which may serve as points of interests throughout this
 
 . kbd:[Enter] : This grey highlight with white outline indicates a keyboard's key to use.
 
+. [underline]#underlined# : This underline indicates clickable links referring to other sections of this *User Guide*. When used in conjunction with a grey highlight (e.g. <<student-active-command,`student active`>>), this indicates a clickable reference to another command.
+
 [NOTE]
 This symbol and corresponding box has information that you may wish to take note of.
 
@@ -141,7 +143,7 @@ Format: `exit`
 The following commands below are part of the application's *Degree Management*, which allow you to declare important details of your academic plan, such as your `majors` and `specialisations`.
 
 [NOTE]
-All the following commands require a `student` to be selected (using the `student active` command).
+All the following commands require a `student` to be selected (using the <<student-active-command,`student active`>> command).
 
 ==== Declaring your major: `major set`
 
@@ -182,7 +184,7 @@ The following commands below are part of the application's *Grade Management*, w
 You can use this command to display the `grade` of the specified module.
 
 [NOTE]
-This command requires a timetable to be selected (using the `timetable active` command).
+This command requires a timetable to be selected (using the <<timetable-active-command,`timetable active`>> command).
 
 Format: `module grade MODULE_CODE`
 
@@ -193,7 +195,7 @@ Example:
 Furthermore, you can also use this follow-up command to set the `grade` of the specified module.
 
 [NOTE]
-This command requires a timetable to be selected (using the `timetable active` command).
+This command requires a timetable to be selected (using the <<timetable-active-command,`timetable active`>> command).
 
 Format: `module grade MODULE_CODE grade/GRADE`
 
@@ -203,10 +205,10 @@ Example:
 
 ==== Viewing a student's grade: `student grade`
 
-You can use this command to display  the cumulative grade of the selected student (_see the `student active` command_).
+You can use this command to display  the cumulative grade of the selected student (see the <<student-active-command,`student active`>> command).
 
 [NOTE]
-This command requires a student to be selected (using the `student active` command).
+This command requires a student to be selected (using the <<student-active-command,`student active`>> command).
 
 Format: `student grade`
 
@@ -223,11 +225,11 @@ When managing your `modules`, you will be able to see the *Module View Screen* (
 image::ModuleList.png[width="600", align="left"]
 
 [NOTE]
-All the following commands require a `timetable` to be selected (_using the `timetable active` command_).
+All the following commands require a `timetable` to be selected (using the <<timetable-active-command,`timetable active`>> command).
 
 ==== Adding a module: `module add`
 
-You can use this command to add a `module` to your `timetable` for the selected `semester` (see `timetable active`) and `student` (see `student active`).
+You can use this command to add a `module` to your `timetable` for the selected `semester` (see the <<timetable-active-command,`timetable active`>> command) and `student` (see the <<student-active-command,`student active`>> command).
 
 Format: `module add MODULE_CODE`
 
@@ -237,7 +239,7 @@ Example:
 
 ==== Removing a module: `module remove`
 
-You can use this command to remove a `module` to your `timetable` for the selected `semester` (see `timetable active`) and `student` (see `student active`).
+You can use this command to remove a `module` to your `timetable` for the selected `semester` (see the <<timetable-active-command,`timetable active`>> command) and `student` (see the <<student-active-command,`student active`>> command).
 
 Format: `module remove MODULE_CODE`
 
@@ -247,7 +249,7 @@ Example:
 
 ==== Viewing added modules: `module list`
 
-You can use this command to display a list of `modules` of your `timetable` for the selected `semester` (see `timetable active`) and `student` (see `student active`).
+You can use this command to display a list of `modules` of your `timetable` for the selected `semester` (see the <<timetable-active-command,`timetable active`>> command) and `student` (see the <<student-active-command,`student active`>> command).
 
 Format: `module list`
 
@@ -257,7 +259,7 @@ Example:
 
 ==== Adding an exempted module: `exempt add`
 
-You can use this command to add an exempted module `module` for the selected `student` (see `student active`).
+You can use this command to add an exempted module for the selected `student` (see the <<student-active-command,`student active`>> command).
 
 Format: `module add MODULE_CODE`
 
@@ -267,7 +269,7 @@ Example:
 
 ==== Removing an exempted module: `exempt remove`
 
-You can use this command to remove an exempted module `module` from the selected `student` (see `student active`).
+You can use this command to remove an exempted module from the selected `student` (see the <<student-active-command,`student active`>> command).
 
 Format: `module remove MODULE_CODE`
 
@@ -314,6 +316,7 @@ Example:
 
 * `student remove 1`
 
+[[student-active-command]]
 ==== Selecting a student: `student active`
 
 You can use this command to select the student with the number `INDEX` from the student list.
@@ -344,11 +347,11 @@ When managing your `timetable`, you will be able to see the *Timetable View Scre
 image::TimeTableList.png[width="600", align="left"]
 
 [NOTE]
-All the following commands require a student to be selected (_using the `student active` command_).
+All the following commands require a student to be selected (using the <<student-active-command,`student active`>> command).
 
 ==== Adding a timetable: `timetable add`
 
-You can use this command to add a `timetable` to the specified `semester` of the selected `student` (see `student active`).
+You can use this command to add a `timetable` to the specified `semester` of the selected `student` (see the <<student-active-command,`student active`>> command).
 
 Format: `timetable add year/YEAR sem/SEM`
 
@@ -358,7 +361,7 @@ Example:
 
 ==== Removing a timetable: `timetable remove`
 
-You can use this command to remove a `timetable` to the specified `semester` of the selected `student` (see `student active`).
+You can use this command to remove a `timetable` to the specified `semester` of the selected `student` (see the <<student-active-command,`student active`>> command).
 
 Format: `timetable remove year/YEAR sem/SEM`
 
@@ -366,10 +369,10 @@ Example:
 
 * `timetable remove year/2 sem/ONE`
 
+[[timetable-active-command]]
 ==== Selecting a timetable: `timetable active`
 
-You can use this command to select the `timetable` of the specified `semester` of the selected `student` (see `student active`).
-
+You can use this command to select the `timetable` of the specified `semester` of the selected `student` (see the <<student-active-command,`student active`>> command).
 Format: `timetable active year/YEAR sem/SEM`
 
 Example:
@@ -378,7 +381,7 @@ Example:
 
 ==== Listing timetables: `timetable list`
 
-You can use this command to list all the `timetables`  of the selected `student` (see `student active`).
+You can use this command to list all the `timetables`  of the selected `student` (see the <<student-active-command,`student active`>> command).
 
 Format: `timetable list`
 

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -139,6 +139,57 @@ When you are done using the application, you can exit the program with the `exit
 
 Format: `exit`
 
+[[student-management]]
+=== Student Management
+
+The following commands below are part of the application's *Student Management*, which allow you manage the students *which include you* for the academic planning. You are highly encouraged to use this *Student Management* feature to explore different academic plans.
+
+When managing students, you will be able to see the *Student View Screen* (_Figure 3. below_).
+
+.Student List View
+image::StudentList.png[width="600", align="left"]
+
+==== Adding a student: `student add`
+
+You can use this command to add a <<student-management,student>> to the student list.
+
+Format: `student add n/NAME major/MAJOR`
+
+Example:
+
+* `student add n/Alice major/CS`
+
+==== Removing a student: `student remove`
+
+You can use this command to remove the <<student-management,student>> with the number `INDEX` from the student list.
+
+Format: `student remove INDEX`
+
+Example:
+
+* `student remove 1`
+
+[[student-active-command]]
+==== Selecting a student: `student active`
+
+You can use this command to select the <<student-management,student>> with the number `INDEX` from the student list.
+
+Format: `student active INDEX`
+
+Example:
+
+* `student active 1`
+
+==== Viewing the student list: `student list`
+
+You can use this command to display a numbered list of students in the student list (if populated).
+
+Format: `student list`
+
+Example:
+
+* `student list`
+
 [[degree-management]]
 === Degree Management
 
@@ -219,6 +270,59 @@ Example:
 
 * `student grade`
 
+[[timetable-management]]
+=== Timetable Management
+
+The following commands below are part of the application's *Timetable Management*, which allow you manage the timetables of your academic plan.
+
+When managing your <<timetable-management,timetable>>, you will be able to see the *Timetable View Screen* (_Figure 4. below_).
+
+.Timetable List View
+image::TimeTableList.png[width="600", align="left"]
+
+[NOTE]
+All the following commands require a <<student-management,student>> to be selected (using the <<student-active-command,`student active`>> command).
+
+==== Adding a timetable: `timetable add`
+
+You can use this command to add a <<timetable-management,timetable>> to the specified <<common-parameter-list,semester>> of the selected <<student-management,student>> (see the <<student-active-command,`student active`>> command).
+
+Format: `timetable add year/YEAR sem/SEM`
+
+Example:
+
+* `timetable add year/2 sem/ONE`
+
+==== Removing a timetable: `timetable remove`
+
+You can use this command to remove a <<timetable-management,timetable>> to the specified <<common-parameter-list,semester>> of the selected <<student-management,student>> (see the <<student-active-command,`student active`>> command).
+
+Format: `timetable remove year/YEAR sem/SEM`
+
+Example:
+
+* `timetable remove year/2 sem/ONE`
+
+[[timetable-active-command]]
+==== Selecting a timetable: `timetable active`
+
+You can use this command to select a <<timetable-management,timetable>> of the specified <<common-parameter-list,semester>> of the selected <<student-management,student>> (see the <<student-active-command,`student active`>> command).
+Format: `timetable active year/YEAR sem/SEM`
+
+Example:
+
+* `timetable active year/2 sem/ONE`
+
+==== Listing timetables: `timetable list`
+
+You can use this command to list all the <<timetable-management,timetables>>  of the selected <<student-management,student>> (see the <<student-active-command,`student active`>> command).
+
+Format: `timetable list`
+
+Example:
+
+* `timetable list`
+
 [[module-management]]
 === Module Management
 The following commands below are part of the application's *Module Management*, which allow you manage the modules of your academic plan.
@@ -291,110 +395,6 @@ Example:
 
 * `exempt list`
 
-[[student-management]]
-=== Student Management
-
-The following commands below are part of the application's *Student Management*, which allow you manage the students *which include you* for the academic planning. You are highly encouraged to use this *Student Management* feature to explore different academic plans.
-
-When managing students, you will be able to see the *Student View Screen* (_Figure 3. below_).
-
-.Student List View
-image::StudentList.png[width="600", align="left"]
-
-==== Adding a student: `student add`
-
-You can use this command to add a <<student-management,student>> to the student list.
-
-Format: `student add n/NAME major/MAJOR`
-
-Example:
-
-* `student add n/Alice major/CS`
-
-==== Removing a student: `student remove`
-
-You can use this command to remove the <<student-management,student>> with the number `INDEX` from the student list.
-
-Format: `student remove INDEX`
-
-Example:
-
-* `student remove 1`
-
-[[student-active-command]]
-==== Selecting a student: `student active`
-
-You can use this command to select the <<student-management,student>> with the number `INDEX` from the student list.
-
-Format: `student active INDEX`
-
-Example:
-
-* `student active 1`
-
-==== Viewing the student list: `student list`
-
-You can use this command to display a numbered list of students in the student list (if populated).
-
-Format: `student list`
-
-Example:
-
-* `student list`
-
-[[timetable-management]]
-=== Timetable Management
-
-The following commands below are part of the application's *Timetable Management*, which allow you manage the timetables of your academic plan.
-
-When managing your <<timetable-management,timetable>>, you will be able to see the *Timetable View Screen* (_Figure 4. below_).
-
-.Timetable List View
-image::TimeTableList.png[width="600", align="left"]
-
-[NOTE]
-All the following commands require a <<student-management,student>> to be selected (using the <<student-active-command,`student active`>> command).
-
-==== Adding a timetable: `timetable add`
-
-You can use this command to add a <<timetable-management,timetable>> to the specified <<common-parameter-list,semester>> of the selected <<student-management,student>> (see the <<student-active-command,`student active`>> command).
-
-Format: `timetable add year/YEAR sem/SEM`
-
-Example:
-
-* `timetable add year/2 sem/ONE`
-
-==== Removing a timetable: `timetable remove`
-
-You can use this command to remove a <<timetable-management,timetable>> to the specified <<common-parameter-list,semester>> of the selected <<student-management,student>> (see the <<student-active-command,`student active`>> command).
-
-Format: `timetable remove year/YEAR sem/SEM`
-
-Example:
-
-* `timetable remove year/2 sem/ONE`
-
-[[timetable-active-command]]
-==== Selecting a timetable: `timetable active`
-
-You can use this command to select a <<timetable-management,timetable>> of the specified <<common-parameter-list,semester>> of the selected <<student-management,student>> (see the <<student-active-command,`student active`>> command).
-Format: `timetable active year/YEAR sem/SEM`
-
-Example:
-
-* `timetable active year/2 sem/ONE`
-
-==== Listing timetables: `timetable list`
-
-You can use this command to list all the <<timetable-management,timetables>>  of the selected <<student-management,student>> (see the <<student-active-command,`student active`>> command).
-
-Format: `timetable list`
-
-Example:
-
-* `timetable list`
-
 === Saving Your Data
 
 NUS Module Planner data is saved to the hard disk automatically after any command that changes the data. +
@@ -464,6 +464,13 @@ If you need more in-depth information on a specific command, you can kbd:[CTRL +
 * *Viewing help* : `help`
 * *Exiting the program* : `exit`
 
+=== Student Management
+
+* *Adding a student* : `student add`
+* *Removing a student* : `student remove`
+* *Selecting a student* : `student active`
+* *Viewing the student list* : `student list`
+
 === Degree Management
 
 * *Declaring your major* : `major set`
@@ -475,6 +482,13 @@ If you need more in-depth information on a specific command, you can kbd:[CTRL +
 * *Managing a module's grade* : `module grade`
 * *Viewing a student's grade* : `student grade`
 
+=== Timetable Management
+
+* *Adding a timetable* : `timetable add`
+* *Removing a timetable* : `timetable remove`
+* *Selecting a timetable* : `timetable active`
+* *Listing timetables* : `timetable list`
+
 === Module Management
 
 * *Adding a module* : `module add`
@@ -483,17 +497,3 @@ If you need more in-depth information on a specific command, you can kbd:[CTRL +
 * *Adding an exempted module* : `exempt add`
 * *Removing an exempted module* : `exempt remove`
 * *Viewing exempted modules* : `exempt list`
-
-=== Student Management
-
-* *Adding a student* : `student add`
-* *Removing a student* : `student remove`
-* *Selecting a student* : `student active`
-* *Viewing the student list* : `student list`
-
-=== Timetable Management
-
-* *Adding a timetable* : `timetable add`
-* *Removing a timetable* : `timetable remove`
-* *Selecting a timetable* : `timetable active`
-* *Listing timetables* : `timetable list`

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -96,10 +96,10 @@ Before you dive into the commands themselves, do familiarise yourself with how t
 ====
 *Command Format*
 
-* Words in `UPPER_CASE` are the parameters to be supplied by the user e.g. in `add n/NAME`, `NAME` is a parameter which can be used as `add n/John Doe`.
-* Items in square brackets are optional e.g `n/NAME [t/TAG]` can be used as `n/John Doe t/friend` or as `n/John Doe`.
-* Items with `…`​ after them can be used multiple times including zero times e.g. `[t/TAG]...` can be used as `{nbsp}` (i.e. 0 times), `t/friend`, `t/friend t/family` etc.
-* Parameters can be in any order e.g. if the command specifies `n/NAME p/PHONE_NUMBER`, `p/PHONE_NUMBER n/NAME` is also acceptable.
+* Words in `UPPER_CASE` are the parameters to be supplied by you (e.g. in `student add n/NAME major/MAJOR`, `NAME` is a parameter which can be used as `student add n/John Doe major/CS`).
+* Items in square brackets are optional (e.g `n/NAME [t/TAG]` can be used as `n/John Doe t/friend` or as `n/John Doe`).
+* Items with `…`​ after them can be used multiple times including zero times (e.g. `[t/TAG]...` can be used as `{nbsp}` (i.e. 0 times), `t/friend`, `t/friend t/family` etc).
+* Parameters can be in any order (e.g. if the command specifies `n/NAME major/MAJOR`, `major/MAJOR n/NAME` is also acceptable).
 ====
 
 ====
@@ -179,10 +179,10 @@ The following commands below are part of the application's *Grade Management*, w
 
 ==== Managing a module's grade: `module grade`
 
-This command displays the `grade` of the specified module.
+You can use this command to display the `grade` of the specified module.
 
 [NOTE]
-This command require a timetable to be selected (using the `timetable active` command).
+This command requires a timetable to be selected (using the `timetable active` command).
 
 Format: `module grade MODULE_CODE`
 
@@ -190,10 +190,10 @@ Example:
 
 * `module grade CS2040`
 
-Furthermore, this follow-up command sets the `grade` of the specified module.
+Furthermore, you can also use this follow-up command to set the `grade` of the specified module.
 
 [NOTE]
-This command require a timetable to be selected (using the `timetable active` command).
+This command requires a timetable to be selected (using the `timetable active` command).
 
 Format: `module grade MODULE_CODE grade/GRADE`
 
@@ -203,10 +203,10 @@ Example:
 
 ==== Viewing a student's grade: `student grade`
 
-This command displays  the cumulative grade of the selected student (_see the `student active` command_).
+You can use this command to display  the cumulative grade of the selected student (_see the `student active` command_).
 
 [NOTE]
-This command require a student to be selected (using the `student active` command).
+This command requires a student to be selected (using the `student active` command).
 
 Format: `student grade`
 
@@ -227,7 +227,7 @@ All the following commands require a `timetable` to be selected (_using the `tim
 
 ==== Adding a module: `module add`
 
-This command adds a `module` to your `timetable` for the selected `semester` (see `timetable active`) and `student` (see `student active`).
+You can use this command to add a `module` to your `timetable` for the selected `semester` (see `timetable active`) and `student` (see `student active`).
 
 Format: `module add MODULE_CODE`
 
@@ -237,7 +237,7 @@ Example:
 
 ==== Removing a module: `module remove`
 
-This command removes a `module` to your `timetable` for the selected `semester` (see `timetable active`) and `student` (see `student active`).
+You can use this command to remove a `module` to your `timetable` for the selected `semester` (see `timetable active`) and `student` (see `student active`).
 
 Format: `module remove MODULE_CODE`
 
@@ -247,7 +247,7 @@ Example:
 
 ==== Viewing added modules: `module list`
 
-This command displays a list of `modules` of your `timetable` for the selected `semester` (see `timetable active`) and `student` (see `student active`).
+You can use this command to display a list of `modules` of your `timetable` for the selected `semester` (see `timetable active`) and `student` (see `student active`).
 
 Format: `module list`
 
@@ -257,7 +257,7 @@ Example:
 
 ==== Adding an exempted module: `exempt add`
 
-This command adds an exempted module `module` for the selected `student` (see `student active`).
+You can use this command to add an exempted module `module` for the selected `student` (see `student active`).
 
 Format: `module add MODULE_CODE`
 
@@ -267,7 +267,7 @@ Example:
 
 ==== Removing an exempted module: `exempt remove`
 
-This command removes an exempted module `module` from the selected `student` (see `student active`).
+You can use this command to remove an exempted module `module` from the selected `student` (see `student active`).
 
 Format: `module remove MODULE_CODE`
 
@@ -277,7 +277,7 @@ Example:
 
 ==== Viewing exempted modules: `exempt list`
 
-This command displays a list of `modules` that you have declared as exempted.
+You can use this command to display a list of `modules` that you have declared as exempted.
 
 Format: `exempt list`
 
@@ -296,7 +296,7 @@ image::StudentList.png[width="600", align="left"]
 
 ==== Adding a student: `student add`
 
-This command adds a `student` to the student list.
+You can use this command to add a `student` to the student list.
 
 Format: `student add n/NAME major/MAJOR`
 
@@ -306,7 +306,7 @@ Example:
 
 ==== Removing a student: `student remove`
 
-This command removes the `student` with the number `INDEX` from the student list.
+You can use this command to remove the `student` with the number `INDEX` from the student list.
 
 Format: `student remove INDEX`
 
@@ -316,7 +316,7 @@ Example:
 
 ==== Selecting a student: `student active`
 
-This command selects the student with the number `INDEX` from the student list.
+You can use this command to select the student with the number `INDEX` from the student list.
 
 Format: `student active INDEX`
 
@@ -326,7 +326,7 @@ Example:
 
 ==== Viewing the student list: `student list`
 
-This commands displays a numbered list of students in the student list (if populated).
+You can use this command to display a numbered list of students in the student list (if populated).
 
 Format: `student list`
 
@@ -348,7 +348,7 @@ All the following commands require a student to be selected (_using the `student
 
 ==== Adding a timetable: `timetable add`
 
-This command adds a `timetable` to the specified `semester` of the selected `student` (see `student active`).
+You can use this command to add a `timetable` to the specified `semester` of the selected `student` (see `student active`).
 
 Format: `timetable add year/YEAR sem/SEM`
 
@@ -358,7 +358,7 @@ Example:
 
 ==== Removing a timetable: `timetable remove`
 
-This command removes a `timetable` to the specified `semester` of the selected `student` (see `student active`).
+You can use this command to remove a `timetable` to the specified `semester` of the selected `student` (see `student active`).
 
 Format: `timetable remove year/YEAR sem/SEM`
 
@@ -368,7 +368,7 @@ Example:
 
 ==== Selecting a timetable: `timetable active`
 
-This command selects the `timetable` of the specified `semester` of the selected `student` (see `student active`).
+You can use this command to select the `timetable` of the specified `semester` of the selected `student` (see `student active`).
 
 Format: `timetable active year/YEAR sem/SEM`
 
@@ -378,7 +378,7 @@ Example:
 
 ==== Listing timetables: `timetable list`
 
-This command lists all the `timetables`  of the selected `student` (see `student active`).
+You can use this command to list all the `timetables`  of the selected `student` (see `student active`).
 
 Format: `timetable list`
 
@@ -404,7 +404,7 @@ _{Explain how the user can share their data files here!}_
 
 == FAQ
 
-This provides a list of *Frequently Asked Questions (FAQ)*, that users may have!
+This provides a list of *Frequently Asked Questions (FAQ)* that you may have.
 
 *Q*: How do I transfer my data to another Computer? +
 *A*: Install the app in the other computer and overwrite the empty data file it creates with the file that contains the data of your previous NUSModPlnr folder.

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -105,6 +105,7 @@ Before you dive into the commands themselves, do familiarise yourself with how t
 ====
 
 ====
+[[common-parameter-list]]
 *Common Parameters*
 
 These are parameters that are commonly used in commands available in NUSModPlnr.
@@ -114,9 +115,9 @@ These are parameters that are commonly used in commands available in NUSModPlnr.
 ** Must be a positive integer
 * `NAME` - a name of a plan
 ** Must be alphanumeric, possibly with spaces
-* `SEM`
+* `SEM` - an academic semester
 ** Must be one of the following: `ONE`, `TWO`, `SPECIAL_ONE`, `SPECIAL_TWO`
-* `YEAR` - a year number
+* `YEAR` - a year number of your degree (e.g. year 1, 2, ...)
 ** Must be a non-negative integer
 ====
 
@@ -138,16 +139,17 @@ When you are done using the application, you can exit the program with the `exit
 
 Format: `exit`
 
+[[degree-management]]
 === Degree Management
 
-The following commands below are part of the application's *Degree Management*, which allow you to declare important details of your academic plan, such as your `majors` and `specialisations`.
+The following commands below are part of the application's *Degree Management*, which allow you to declare important details of your academic plan, such as your <<glossary,majors>> and <<glossary,specialisations>>.
 
 [NOTE]
-All the following commands require a `student` to be selected (using the <<student-active-command,`student active`>> command).
+All the following commands require a <<student-management,student>> to be selected (using the <<student-active-command,`student active`>> command).
 
 ==== Declaring your major: `major set`
 
-You can use this command to declare the `major` of your studies, which is also required for the module planning.
+You can use this command to declare the <<degree-management,major>> of your studies, which is also required for the module planning.
 
 Format: `major set MAJOR`
 
@@ -157,7 +159,7 @@ Examples:
 
 ==== Declaring your specialisation: `specialisation set`
 
-You can use this command to declare any `specialisations` in your studies, should you require them in module planning.
+You can use this command to declare any <<degree-management,specialisations>> in your studies, should you require them in module planning.
 
 Format: `specalisation set [SPEC]`
 
@@ -175,13 +177,14 @@ Examples:
 
 * `major status`
 
+[[grade-management]]
 === Grade Management
 
-The following commands below are part of the application's *Grade Management*, which allow you to manage and view your `grades` to see modules affected in your academic plan.
+The following commands below are part of the application's *Grade Management*, which allow you to manage and view your grades to see modules affected in your academic plan.
 
 ==== Managing a module's grade: `module grade`
 
-You can use this command to display the `grade` of the specified module.
+You can use this command to display the <<grade-management,grade>> of the specified module.
 
 [NOTE]
 This command requires a timetable to be selected (using the <<timetable-active-command,`timetable active`>> command).
@@ -192,7 +195,7 @@ Example:
 
 * `module grade CS2040`
 
-Furthermore, you can also use this follow-up command to set the `grade` of the specified module.
+Furthermore, you can also use this follow-up command to set the <<grade-management,grade>> of the specified module.
 
 [NOTE]
 This command requires a timetable to be selected (using the <<timetable-active-command,`timetable active`>> command).
@@ -216,20 +219,21 @@ Example:
 
 * `student grade`
 
+[[module-management]]
 === Module Management
-The following commands below are part of the application's *Module Management*, which allow you manage the `modules` of your academic plan.
+The following commands below are part of the application's *Module Management*, which allow you manage the modules of your academic plan.
 
-When managing your `modules`, you will be able to see the *Module View Screen* (_Figure 2. below_).
+When managing your <<module-management,modules>>, you will be able to see the *Module View Screen* (_Figure 2. below_).
 
 .Home Screen View
 image::ModuleList.png[width="600", align="left"]
 
 [NOTE]
-All the following commands require a `timetable` to be selected (using the <<timetable-active-command,`timetable active`>> command).
+All the following commands require a <<timetable-management,timetable>>  to be selected (using the <<timetable-active-command,`timetable active`>> command).
 
 ==== Adding a module: `module add`
 
-You can use this command to add a `module` to your `timetable` for the selected `semester` (see the <<timetable-active-command,`timetable active`>> command) and `student` (see the <<student-active-command,`student active`>> command).
+You can use this command to add a <<module-management,module>> to your <<timetable-management,timetable>>  for the selected <<common-parameter-list,semester>> (see the <<timetable-active-command,`timetable active`>> command) and <<student-management,student>> (see the <<student-active-command,`student active`>> command).
 
 Format: `module add MODULE_CODE`
 
@@ -239,7 +243,7 @@ Example:
 
 ==== Removing a module: `module remove`
 
-You can use this command to remove a `module` to your `timetable` for the selected `semester` (see the <<timetable-active-command,`timetable active`>> command) and `student` (see the <<student-active-command,`student active`>> command).
+You can use this command to remove a <<module-management,module>> to your <<timetable-management,timetable>> for the selected <<common-parameter-list,semester>> (see the <<timetable-active-command,`timetable active`>> command) and <<student-management,student>> (see the <<student-active-command,`student active`>> command).
 
 Format: `module remove MODULE_CODE`
 
@@ -249,7 +253,7 @@ Example:
 
 ==== Viewing added modules: `module list`
 
-You can use this command to display a list of `modules` of your `timetable` for the selected `semester` (see the <<timetable-active-command,`timetable active`>> command) and `student` (see the <<student-active-command,`student active`>> command).
+You can use this command to display a list of <<module-management,modules>> of your <<timetable-management,timetable>> for the selected <<common-parameter-list,semester>> (see the <<timetable-active-command,`timetable active`>> command) and <<student-management,student>> (see the <<student-active-command,`student active`>> command).
 
 Format: `module list`
 
@@ -259,9 +263,9 @@ Example:
 
 ==== Adding an exempted module: `exempt add`
 
-You can use this command to add an exempted module for the selected `student` (see the <<student-active-command,`student active`>> command).
+You can use this command to add an exempted module for the selected <<student-management,student>> (see the <<student-active-command,`student active`>> command).
 
-Format: `module add MODULE_CODE`
+Format: `exempt add MODULE_CODE`
 
 Example:
 
@@ -269,9 +273,9 @@ Example:
 
 ==== Removing an exempted module: `exempt remove`
 
-You can use this command to remove an exempted module from the selected `student` (see the <<student-active-command,`student active`>> command).
+You can use this command to remove an exempted module from the selected <<student-management,student>> (see the <<student-active-command,`student active`>> command).
 
-Format: `module remove MODULE_CODE`
+Format: `exempt remove MODULE_CODE`
 
 Example:
 
@@ -279,7 +283,7 @@ Example:
 
 ==== Viewing exempted modules: `exempt list`
 
-You can use this command to display a list of `modules` that you have declared as exempted.
+You can use this command to display a list of <<module-management,modules>> that you have declared as exempted.
 
 Format: `exempt list`
 
@@ -287,18 +291,19 @@ Example:
 
 * `exempt list`
 
+[[student-management]]
 === Student Management
 
-The following commands below are part of the application's *Student Management*, which allow you manage the `students` *which include you* for the academic planning.
+The following commands below are part of the application's *Student Management*, which allow you manage the students *which include you* for the academic planning. You are highly encouraged to use this *Student Management* feature to explore different academic plans.
 
-When managing `students`, you will be able to see the *Student View Screen* (_Figure 3. below_).
+When managing students, you will be able to see the *Student View Screen* (_Figure 3. below_).
 
 .Student List View
 image::StudentList.png[width="600", align="left"]
 
 ==== Adding a student: `student add`
 
-You can use this command to add a `student` to the student list.
+You can use this command to add a <<student-management,student>> to the student list.
 
 Format: `student add n/NAME major/MAJOR`
 
@@ -308,7 +313,7 @@ Example:
 
 ==== Removing a student: `student remove`
 
-You can use this command to remove the `student` with the number `INDEX` from the student list.
+You can use this command to remove the <<student-management,student>> with the number `INDEX` from the student list.
 
 Format: `student remove INDEX`
 
@@ -319,7 +324,7 @@ Example:
 [[student-active-command]]
 ==== Selecting a student: `student active`
 
-You can use this command to select the student with the number `INDEX` from the student list.
+You can use this command to select the <<student-management,student>> with the number `INDEX` from the student list.
 
 Format: `student active INDEX`
 
@@ -337,21 +342,22 @@ Example:
 
 * `student list`
 
+[[timetable-management]]
 === Timetable Management
 
-The following commands below are part of the application's *Timetable Management*, which allow you manage the `timetables` of your academic plan.
+The following commands below are part of the application's *Timetable Management*, which allow you manage the timetables of your academic plan.
 
-When managing your `timetable`, you will be able to see the *Timetable View Screen* (_Figure 4. below_).
+When managing your <<timetable-management,timetable>>, you will be able to see the *Timetable View Screen* (_Figure 4. below_).
 
 .Timetable List View
 image::TimeTableList.png[width="600", align="left"]
 
 [NOTE]
-All the following commands require a student to be selected (using the <<student-active-command,`student active`>> command).
+All the following commands require a <<student-management,student>> to be selected (using the <<student-active-command,`student active`>> command).
 
 ==== Adding a timetable: `timetable add`
 
-You can use this command to add a `timetable` to the specified `semester` of the selected `student` (see the <<student-active-command,`student active`>> command).
+You can use this command to add a <<timetable-management,timetable>> to the specified <<common-parameter-list,semester>> of the selected <<student-management,student>> (see the <<student-active-command,`student active`>> command).
 
 Format: `timetable add year/YEAR sem/SEM`
 
@@ -361,7 +367,7 @@ Example:
 
 ==== Removing a timetable: `timetable remove`
 
-You can use this command to remove a `timetable` to the specified `semester` of the selected `student` (see the <<student-active-command,`student active`>> command).
+You can use this command to remove a <<timetable-management,timetable>> to the specified <<common-parameter-list,semester>> of the selected <<student-management,student>> (see the <<student-active-command,`student active`>> command).
 
 Format: `timetable remove year/YEAR sem/SEM`
 
@@ -372,7 +378,7 @@ Example:
 [[timetable-active-command]]
 ==== Selecting a timetable: `timetable active`
 
-You can use this command to select the `timetable` of the specified `semester` of the selected `student` (see the <<student-active-command,`student active`>> command).
+You can use this command to select a <<timetable-management,timetable>> of the specified <<common-parameter-list,semester>> of the selected <<student-management,student>> (see the <<student-active-command,`student active`>> command).
 Format: `timetable active year/YEAR sem/SEM`
 
 Example:
@@ -381,7 +387,7 @@ Example:
 
 ==== Listing timetables: `timetable list`
 
-You can use this command to list all the `timetables`  of the selected `student` (see the <<student-active-command,`student active`>> command).
+You can use this command to list all the <<timetable-management,timetables>>  of the selected <<student-management,student>> (see the <<student-active-command,`student active`>> command).
 
 Format: `timetable list`
 
@@ -415,6 +421,7 @@ This provides a list of *Frequently Asked Questions (FAQ)* that you may have.
 [TIP]
 If you have questions, feel free to open an issue in our *Issue Tracker* on GitHub!
 
+[[glossary]]
 == Glossary
 
 This *Glossary* provides explanations for keywords used throughout the *User Guide*.


### PR DESCRIPTION
Remove obsolete commands, reorder structure of UG and fix some typos based on feedback from PE-D. Links between sections are also added (e.g. for commands to link to the subsection of the command used)