### PR TITLE
Fix many parsing bugs, improved error messages

### DIFF
--- a/src/main/java/seedu/planner/commons/core/Messages.java
+++ b/src/main/java/seedu/planner/commons/core/Messages.java
@@ -6,7 +6,8 @@ package seedu.planner.commons.core;
 public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
-    public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
+    public static final String MESSAGE_UNKNOWN_SUBCOMMAND = "Unknown subcommand\n%1$s";
+    public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format!\n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
 

--- a/src/main/java/seedu/planner/commons/util/StringUtil.java
+++ b/src/main/java/seedu/planner/commons/util/StringUtil.java
@@ -67,4 +67,23 @@ public class StringUtil {
             return false;
         }
     }
+
+    /**
+     * Returns true if {@code s} represents a non-negative unsigned integer
+     * e.g. 0, 1, 2, 3, ..., {@code Integer.MAX_VALUE} <br>
+     * Will return false for any other non-null string input
+     * e.g. empty string, "-1", "+0", "+1", and " 2 " (untrimmed), "3 0" (contains whitespace), "1 a" (contains letters)
+     *
+     * @throws NullPointerException if {@code s} is null.
+     */
+    public static boolean isNonNegativeUnsignedInteger(String s) {
+        requireNonNull(s);
+
+        try {
+            int value = Integer.parseInt(s);
+            return value >= 0 && !s.startsWith("+"); // "+1" is successfully parsed by Integer#parseInt(String)
+        } catch (NumberFormatException nfe) {
+            return false;
+        }
+    }
 }

--- a/src/main/java/seedu/planner/logic/commands/exemptions/ExemptAddCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/exemptions/ExemptAddCommand.java
@@ -16,11 +16,9 @@ import seedu.planner.model.module.ModuleCode;
 public class ExemptAddCommand extends ExemptCommand {
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_NOT_IMPLEMENTED_YET = "'" + getQualifiedCommand(COMMAND_WORD)
-        + "' command not implemented yet";
-
     public static final String MESSAGE_USAGE = getQualifiedCommand(COMMAND_WORD)
         + ": Adds the module to list of exempted modules.\n"
+        + "Parameters: MODULE_CODE (must be a valid NUS module code)\n"
         + "Example: " + getQualifiedCommand(COMMAND_WORD) + " CS2030";
 
     public static final String MESSAGE_ADD_MODULE_SUCCESS = "Added module to exemption list: %1$s";

--- a/src/main/java/seedu/planner/logic/commands/exemptions/ExemptCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/exemptions/ExemptCommand.java
@@ -10,9 +10,9 @@ public abstract class ExemptCommand extends Command {
     public static final String COMMAND_WORD = "exempt";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-        + ":\n"
+        + ": Manage exemptions of the currently active student\n"
         + "Subcommands: add, remove, list\n"
-        + "Example: " + getQualifiedCommand(COMMAND_WORD) + " CS2101";
+        + "Example: " + getQualifiedCommand("add") + " CS2101";
 
 
     /**

--- a/src/main/java/seedu/planner/logic/commands/exemptions/ExemptRemoveCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/exemptions/ExemptRemoveCommand.java
@@ -19,7 +19,7 @@ public class ExemptRemoveCommand extends ExemptCommand {
     public static final String MESSAGE_USAGE = getQualifiedCommand(COMMAND_WORD)
         + ": Removes the module from list of exempted modules.\n"
         + "Parameters: MODULE_CODE (must be a valid NUS module code)\n"
-        + "Example: " + getQualifiedCommand(COMMAND_WORD) + "CS2030";
+        + "Example: " + getQualifiedCommand(COMMAND_WORD) + " CS2030";
 
     public static final String MESSAGE_ADD_MODULE_SUCCESS = "Removed the module from exemptions list: %1$s";
     public static final String MESSAGE_ADD_MODULE_NOT_EXISTS = "Module does not exist in exemptions list: %1$s";

--- a/src/main/java/seedu/planner/logic/commands/exemptions/ExemptRemoveCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/exemptions/ExemptRemoveCommand.java
@@ -16,11 +16,9 @@ import seedu.planner.model.module.ModuleCode;
 public class ExemptRemoveCommand extends ExemptCommand {
     public static final String COMMAND_WORD = "remove";
 
-    public static final String MESSAGE_NOT_IMPLEMENTED_YET = "'" + getQualifiedCommand(COMMAND_WORD)
-        + "' command not implemented yet";
-
     public static final String MESSAGE_USAGE = getQualifiedCommand(COMMAND_WORD)
         + ": Removes the module from list of exempted modules.\n"
+        + "Parameters: MODULE_CODE (must be a valid NUS module code)\n"
         + "Example: " + getQualifiedCommand(COMMAND_WORD) + "CS2030";
 
     public static final String MESSAGE_ADD_MODULE_SUCCESS = "Removed the module from exemptions list: %1$s";

--- a/src/main/java/seedu/planner/logic/commands/module/ModuleAddCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/module/ModuleAddCommand.java
@@ -1,7 +1,6 @@
 package seedu.planner.logic.commands.module;
 
 import static java.util.Objects.requireNonNull;
-
 import static seedu.planner.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Optional;
@@ -22,6 +21,7 @@ public class ModuleAddCommand extends ModuleCommand {
 
     public static final String MESSAGE_USAGE = getQualifiedCommand(COMMAND_WORD)
         + ": Adds the module to list of enrolled modules.\n"
+        + "Parameters: MODULE_CODE (must be a valid NUS module code)\n"
         + "Example: " + getQualifiedCommand(COMMAND_WORD) + " CS2030";
 
     public static final String MESSAGE_ADD_MODULE_SUCCESS = "Added module to timetable: %1$s";

--- a/src/main/java/seedu/planner/logic/commands/module/ModuleCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/module/ModuleCommand.java
@@ -10,9 +10,9 @@ public abstract class ModuleCommand extends Command {
     public static final String COMMAND_WORD = "module";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-        + ":\n"
+        + ": Manage enrollments of the currently active student and timetable\n"
         + "Subcommands: add, remove, list, grade\n"
-        + "Example: " + getQualifiedCommand(COMMAND_WORD) + " CS2030";
+        + "Example: " + getQualifiedCommand("add") + " CS2030";
 
 
     /**

--- a/src/main/java/seedu/planner/logic/commands/module/ModuleRemoveCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/module/ModuleRemoveCommand.java
@@ -16,11 +16,9 @@ import seedu.planner.model.module.ModuleCode;
 public class ModuleRemoveCommand extends ModuleCommand {
     public static final String COMMAND_WORD = "remove";
 
-    public static final String MESSAGE_NOT_IMPLEMENTED_YET = "'" + getQualifiedCommand(COMMAND_WORD)
-        + "' command not implemented yet";
-
     public static final String MESSAGE_USAGE = getQualifiedCommand(COMMAND_WORD)
         + ": Removes the module from list of enrolled modules.\n"
+        + "Parameters: MODULE_CODE (must be a valid NUS module code)\n"
         + "Example: " + getQualifiedCommand(COMMAND_WORD) + "CS2030";
 
     public static final String MESSAGE_ADD_MODULE_SUCCESS = "Removed module from timetable: %1$s";

--- a/src/main/java/seedu/planner/logic/commands/module/ModuleRemoveCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/module/ModuleRemoveCommand.java
@@ -19,7 +19,7 @@ public class ModuleRemoveCommand extends ModuleCommand {
     public static final String MESSAGE_USAGE = getQualifiedCommand(COMMAND_WORD)
         + ": Removes the module from list of enrolled modules.\n"
         + "Parameters: MODULE_CODE (must be a valid NUS module code)\n"
-        + "Example: " + getQualifiedCommand(COMMAND_WORD) + "CS2030";
+        + "Example: " + getQualifiedCommand(COMMAND_WORD) + " CS2030";
 
     public static final String MESSAGE_ADD_MODULE_SUCCESS = "Removed module from timetable: %1$s";
     public static final String MESSAGE_ADD_MODULE_NOT_EXISTS = "Module does not exist in timetable: %1$s";

--- a/src/main/java/seedu/planner/logic/commands/student/StudentActiveCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/student/StudentActiveCommand.java
@@ -18,12 +18,9 @@ import seedu.planner.model.student.Student;
 public class StudentActiveCommand extends StudentCommand {
     public static final String COMMAND_WORD = "active";
 
-    public static final String MESSAGE_NOT_IMPLEMENTED_YET = "'" + getQualifiedCommand(COMMAND_WORD)
-        + "' command not implemented yet";
-
     public static final String MESSAGE_USAGE = getQualifiedCommand(COMMAND_WORD)
         + ": Sets the student from the student list as the active student.\n"
-        + "Parameters: INDEX (must be a positive integer) \n"
+        + "Parameters: INDEX (must be a positive integer)\n"
         + "Example: " + getQualifiedCommand(COMMAND_WORD) + " 1";
 
     public static final String MESSAGE_ACTIVE_STUDENT_SUCCESS = "Set student as active: %1$s";

--- a/src/main/java/seedu/planner/logic/commands/student/StudentAddCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/student/StudentAddCommand.java
@@ -19,14 +19,11 @@ public class StudentAddCommand extends StudentCommand {
     public static final String EXAMPLE_COMMAND =
         getQualifiedCommand(COMMAND_WORD) + " " + PREFIX_NAME + "Mark " + PREFIX_MAJOR + "CS";
 
-    public static final String MESSAGE_NOT_IMPLEMENTED_YET = "'" + getQualifiedCommand(COMMAND_WORD)
-        + "' command not implemented yet";
-
     public static final String MESSAGE_USAGE = getQualifiedCommand(COMMAND_WORD)
         + ": Adds the student to list of student profiles.\n"
         + "Parameters: "
-        + "[" + PREFIX_NAME + "NAME] "
-        + "[" + PREFIX_MAJOR + "MAJOR] \n"
+        + PREFIX_NAME + "NAME "
+        + PREFIX_MAJOR + "MAJOR\n"
         + "Example: " + getQualifiedCommand(COMMAND_WORD) + " n/Alice major/CS";
 
     public static final String MESSAGE_ADD_STUDENT_SUCCESS = "Added student: %1$s";

--- a/src/main/java/seedu/planner/logic/commands/student/StudentCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/student/StudentCommand.java
@@ -10,9 +10,9 @@ public abstract class StudentCommand extends Command {
     public static final String COMMAND_WORD = "student";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-        + ":\n"
-        + "Subcommands: add, remove, active, grade\n"
-        + "Example: " + COMMAND_WORD + " active 1";
+        + ": Manage students in the planner\n"
+        + "Subcommands: add, remove, list, active, grade\n"
+        + "Example: " + getQualifiedCommand("active") + " 1";
 
 
     /**

--- a/src/main/java/seedu/planner/logic/commands/student/StudentGradeCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/student/StudentGradeCommand.java
@@ -23,9 +23,6 @@ import seedu.planner.model.time.StudentSemester;
 public class StudentGradeCommand extends StudentCommand {
     public static final String COMMAND_WORD = "grade";
 
-    public static final String MESSAGE_NOT_IMPLEMENTED_YET = "'" + getQualifiedCommand(COMMAND_WORD)
-        + "' command not implemented yet";
-
     public static final String MESSAGE_USAGE = getQualifiedCommand(COMMAND_WORD)
         + ": Display average grade of active student.\n"
         + "Example: " + getQualifiedCommand(COMMAND_WORD);

--- a/src/main/java/seedu/planner/logic/commands/student/StudentListCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/student/StudentListCommand.java
@@ -15,9 +15,6 @@ import seedu.planner.model.student.Student;
 public class StudentListCommand extends StudentCommand {
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_NOT_IMPLEMENTED_YET = "'" + getQualifiedCommand(COMMAND_WORD)
-        + "' command not implemented yet";
-
     public static final String MESSAGE_USAGE = getQualifiedCommand(COMMAND_WORD)
         + ": List students in the student list.\n"
         + "Example: " + getQualifiedCommand(COMMAND_WORD);

--- a/src/main/java/seedu/planner/logic/commands/student/StudentRemoveCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/student/StudentRemoveCommand.java
@@ -18,12 +18,9 @@ import seedu.planner.model.student.Student;
 public class StudentRemoveCommand extends StudentCommand {
     public static final String COMMAND_WORD = "remove";
 
-    public static final String MESSAGE_NOT_IMPLEMENTED_YET = "'" + getQualifiedCommand(COMMAND_WORD)
-        + "' command not implemented yet";
-
     public static final String MESSAGE_USAGE = getQualifiedCommand(COMMAND_WORD)
         + ": Removes the student from list of student profiles.\n"
-        + "Parameters: INDEX (must be a positive integer) \n"
+        + "Parameters: INDEX (must be a positive integer)\n"
         + "Example: " + getQualifiedCommand(COMMAND_WORD) + " 1";
 
     public static final String MESSAGE_REMOVE_STUDENT_SUCCESS = "Removed student: %1$s";

--- a/src/main/java/seedu/planner/logic/commands/timetable/TimeTableActiveCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/timetable/TimeTableActiveCommand.java
@@ -22,8 +22,8 @@ public class TimeTableActiveCommand extends TimeTableCommand {
     public static final String MESSAGE_USAGE = getQualifiedCommand(COMMAND_WORD)
         + ": Sets the active timetable of the active student.\n"
         + "Parameters: "
-        + "[" + PREFIX_STUDENT_YEAR + "YEAR] "
-        + "[" + PREFIX_STUDENT_SEM + "SEMESTER] \n"
+        + PREFIX_STUDENT_YEAR + "YEAR "
+        + PREFIX_STUDENT_SEM + "SEMESTER\n"
         + "Example: " + getQualifiedCommand(COMMAND_WORD) + " year/1 sem/ONE";
 
     public static final String MESSAGE_ACTIVE_TIMETABLE_SUCCESS = "Set semester as active: %1$s";

--- a/src/main/java/seedu/planner/logic/commands/timetable/TimeTableAddCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/timetable/TimeTableAddCommand.java
@@ -19,14 +19,11 @@ import seedu.planner.model.time.StudentSemester;
 public class TimeTableAddCommand extends TimeTableCommand {
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_NOT_IMPLEMENTED_YET = "'" + getQualifiedCommand(COMMAND_WORD)
-        + "' command not implemented yet";
-
     public static final String MESSAGE_USAGE = getQualifiedCommand(COMMAND_WORD)
         + ": Adds a timetable with the given semester to the active student.\n"
         + "Parameters: "
-        + "[" + PREFIX_STUDENT_YEAR + "YEAR] "
-        + "[" + PREFIX_STUDENT_SEM + "SEMESTER] \n"
+        + PREFIX_STUDENT_YEAR + "YEAR "
+        + PREFIX_STUDENT_SEM + "SEMESTER\n"
         + "Example: " + getQualifiedCommand(COMMAND_WORD) + " year/1 sem/ONE";
 
     public static final String MESSAGE_ADD_TIMETABLE_SUCCESS = "Added timetable to semester: %1$s";

--- a/src/main/java/seedu/planner/logic/commands/timetable/TimeTableCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/timetable/TimeTableCommand.java
@@ -11,9 +11,9 @@ public abstract class TimeTableCommand extends Command {
     public static final String COMMAND_WORD = "timetable";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-        + ": Modifies the timetable of the currently active student.\n"
+        + ": Manage timetables of the currently active student\n"
         + "Subcommands: add remove active\n"
-        + "Example: " + COMMAND_WORD + " active year/1 sem/ONE";
+        + "Example: " + getQualifiedCommand("active") + " year/1 sem/ONE";
 
 
     /**

--- a/src/main/java/seedu/planner/logic/commands/timetable/TimeTableRemoveCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/timetable/TimeTableRemoveCommand.java
@@ -27,7 +27,7 @@ public class TimeTableRemoveCommand extends TimeTableCommand {
         + "Example: " + getQualifiedCommand(COMMAND_WORD) + " year/1 sem/Semester 1";
 
     public static final String MESSAGE_REMOVE_TIMETABLE_SUCCESS = "Removed timetable from semester: %1$s";
-    public static final String MESSAGE_INVALID_SEMESTER = "Semester does not exists in list of timetables: %1$s";
+    public static final String MESSAGE_INVALID_SEMESTER = "Semester does not exist in list of timetables: %1$s";
 
     private final StudentSemester studentSemester;
 

--- a/src/main/java/seedu/planner/logic/commands/timetable/TimeTableRemoveCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/timetable/TimeTableRemoveCommand.java
@@ -19,14 +19,11 @@ import seedu.planner.model.time.StudentSemester;
 public class TimeTableRemoveCommand extends TimeTableCommand {
     public static final String COMMAND_WORD = "remove";
 
-    public static final String MESSAGE_NOT_IMPLEMENTED_YET = "'" + getQualifiedCommand(COMMAND_WORD)
-        + "' command not implemented yet";
-
     public static final String MESSAGE_USAGE = getQualifiedCommand(COMMAND_WORD)
         + ": Removes a timetable identified by the given semester from the active student.\n"
         + "Parameters: "
-        + "[" + PREFIX_STUDENT_YEAR + "YEAR] "
-        + "[" + PREFIX_STUDENT_SEM + "SEMESTER] \n"
+        + PREFIX_STUDENT_YEAR + "YEAR "
+        + PREFIX_STUDENT_SEM + "SEMESTER\n"
         + "Example: " + getQualifiedCommand(COMMAND_WORD) + " year/1 sem/Semester 1";
 
     public static final String MESSAGE_REMOVE_TIMETABLE_SUCCESS = "Removed timetable from semester: %1$s";

--- a/src/main/java/seedu/planner/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/planner/logic/parser/ParserUtil.java
@@ -5,7 +5,10 @@ import static java.util.Objects.requireNonNull;
 import seedu.planner.commons.core.index.Index;
 import seedu.planner.commons.util.StringUtil;
 import seedu.planner.logic.parser.exceptions.ParseException;
+import seedu.planner.model.grades.LetterGrade;
 import seedu.planner.model.module.ModuleCode;
+import seedu.planner.model.student.Major;
+import seedu.planner.model.student.Name;
 import seedu.planner.model.time.Semester;
 
 /**
@@ -51,6 +54,36 @@ public class ParserUtil {
             return semesterEnum;
         } catch (IllegalArgumentException e) {
             throw new ParseException(Semester.MESSAGE_CONSTRAINTS);
+        }
+    }
+
+    public static Name parseName(String name) throws ParseException {
+        requireNonNull(name);
+        try {
+            final Name modelName = new Name(name);
+            return modelName;
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(Name.MESSAGE_CONSTRAINTS);
+        }
+    }
+
+    public static Major parseMajor(String major) throws ParseException {
+        requireNonNull(major);
+        try {
+            final Major modelMajor = new Major(major);
+            return modelMajor;
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(Major.MESSAGE_CONSTRAINTS);
+        }
+    }
+
+    public static LetterGrade parseLetterGrade(String letterGrade) throws ParseException {
+        requireNonNull(letterGrade);
+        try {
+            final LetterGrade modelLetterGrade = LetterGrade.valueOf(letterGrade);
+            return modelLetterGrade;
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(LetterGrade.MESSAGE_CONSTRAINTS);
         }
     }
 }

--- a/src/main/java/seedu/planner/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/planner/logic/parser/ParserUtil.java
@@ -9,6 +9,7 @@ import seedu.planner.model.grades.LetterGrade;
 import seedu.planner.model.module.ModuleCode;
 import seedu.planner.model.student.Major;
 import seedu.planner.model.student.Name;
+import seedu.planner.model.time.DegreeYear;
 import seedu.planner.model.time.Semester;
 
 /**
@@ -16,7 +17,8 @@ import seedu.planner.model.time.Semester;
  */
 public class ParserUtil {
 
-    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_INVALID_INDEX = "Index must be a non-zero unsigned integer.";
+    public static final String MESSAGE_INVALID_DEGREE_YEAR = "Year must be a non-negative unsigned integer.";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -30,6 +32,20 @@ public class ParserUtil {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
+    }
+
+    /**
+     * Parses {@code zeroBasedYear} into an {@code Index} and returns it. Leading and trailing whitespaces will be
+     * trimmed.
+     *
+     * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
+     */
+    public static DegreeYear parseYear(String year) throws ParseException {
+        String trimmedYear = year.trim();
+        if (!StringUtil.isNonNegativeUnsignedInteger(trimmedYear)) {
+            throw new ParseException(MESSAGE_INVALID_DEGREE_YEAR);
+        }
+        return new DegreeYear(Integer.parseInt(trimmedYear));
     }
 
     /**
@@ -80,7 +96,7 @@ public class ParserUtil {
     public static LetterGrade parseLetterGrade(String letterGrade) throws ParseException {
         requireNonNull(letterGrade);
         try {
-            final LetterGrade modelLetterGrade = LetterGrade.valueOf(letterGrade);
+            final LetterGrade modelLetterGrade = LetterGrade.fromInputName(letterGrade);
             return modelLetterGrade;
         } catch (IllegalArgumentException e) {
             throw new ParseException(LetterGrade.MESSAGE_CONSTRAINTS);

--- a/src/main/java/seedu/planner/logic/parser/exemptions/ExemptAddCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/exemptions/ExemptAddCommandParser.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.planner.logic.commands.exemptions.ExemptAddCommand;
 import seedu.planner.logic.parser.Parser;
+import seedu.planner.logic.parser.ParserUtil;
 import seedu.planner.logic.parser.exceptions.ParseException;
 import seedu.planner.model.module.ModuleCode;
 
@@ -18,11 +19,7 @@ public class ExemptAddCommandParser implements Parser<ExemptAddCommand> {
     public ExemptAddCommand parse(String args) throws ParseException {
         requireNonNull(args);
 
-        try {
-            ModuleCode moduleCode = new ModuleCode(args);
-            return new ExemptAddCommand(moduleCode);
-        } catch (IllegalArgumentException e) {
-            throw new ParseException(e.getMessage());
-        }
+        ModuleCode moduleCode = ParserUtil.parseModuleCode(args);
+        return new ExemptAddCommand(moduleCode);
     }
 }

--- a/src/main/java/seedu/planner/logic/parser/exemptions/ExemptAddCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/exemptions/ExemptAddCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.planner.logic.parser.exemptions;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.planner.logic.commands.exemptions.ExemptAddCommand;
 import seedu.planner.logic.parser.Parser;
@@ -18,6 +19,11 @@ public class ExemptAddCommandParser implements Parser<ExemptAddCommand> {
     @Override
     public ExemptAddCommand parse(String args) throws ParseException {
         requireNonNull(args);
+
+        if (args.trim().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                ExemptAddCommand.MESSAGE_USAGE));
+        }
 
         ModuleCode moduleCode = ParserUtil.parseModuleCode(args);
         return new ExemptAddCommand(moduleCode);

--- a/src/main/java/seedu/planner/logic/parser/exemptions/ExemptCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/exemptions/ExemptCommandParser.java
@@ -1,12 +1,10 @@
 package seedu.planner.logic.parser.exemptions;
 
-import static seedu.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.planner.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.planner.commons.core.Messages.MESSAGE_UNKNOWN_SUBCOMMAND;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.planner.logic.commands.HelpCommand;
 import seedu.planner.logic.commands.exemptions.ExemptCommand;
 import seedu.planner.logic.commands.exemptions.ExemptListCommand;
 import seedu.planner.logic.commands.module.ModuleAddCommand;
@@ -31,7 +29,7 @@ public class ExemptCommandParser implements Parser<ExemptCommand> {
     public ExemptCommand parse(String userInput) throws ParseException {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_UNKNOWN_SUBCOMMAND, ExemptCommand.MESSAGE_USAGE));
         }
 
         final String commandWord = matcher.group("commandWord");
@@ -48,7 +46,7 @@ public class ExemptCommandParser implements Parser<ExemptCommand> {
             return new ExemptListCommand();
 
         default:
-            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+            throw new ParseException(String.format(MESSAGE_UNKNOWN_SUBCOMMAND, ExemptCommand.MESSAGE_USAGE));
         }
     }
 }

--- a/src/main/java/seedu/planner/logic/parser/exemptions/ExemptRemoveCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/exemptions/ExemptRemoveCommandParser.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.planner.logic.commands.exemptions.ExemptRemoveCommand;
 import seedu.planner.logic.parser.Parser;
+import seedu.planner.logic.parser.ParserUtil;
 import seedu.planner.logic.parser.exceptions.ParseException;
 import seedu.planner.model.module.ModuleCode;
 
@@ -18,11 +19,7 @@ public class ExemptRemoveCommandParser implements Parser<ExemptRemoveCommand> {
     public ExemptRemoveCommand parse(String args) throws ParseException {
         requireNonNull(args);
 
-        try {
-            ModuleCode moduleCode = new ModuleCode(args);
-            return new ExemptRemoveCommand(moduleCode);
-        } catch (IllegalArgumentException e) {
-            throw new ParseException(e.getMessage());
-        }
+        ModuleCode moduleCode = ParserUtil.parseModuleCode(args);
+        return new ExemptRemoveCommand(moduleCode);
     }
 }

--- a/src/main/java/seedu/planner/logic/parser/exemptions/ExemptRemoveCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/exemptions/ExemptRemoveCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.planner.logic.parser.exemptions;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.planner.logic.commands.exemptions.ExemptRemoveCommand;
 import seedu.planner.logic.parser.Parser;
@@ -18,6 +19,11 @@ public class ExemptRemoveCommandParser implements Parser<ExemptRemoveCommand> {
     @Override
     public ExemptRemoveCommand parse(String args) throws ParseException {
         requireNonNull(args);
+
+        if (args.trim().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                ExemptRemoveCommand.MESSAGE_USAGE));
+        }
 
         ModuleCode moduleCode = ParserUtil.parseModuleCode(args);
         return new ExemptRemoveCommand(moduleCode);

--- a/src/main/java/seedu/planner/logic/parser/module/ModuleAddCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/module/ModuleAddCommandParser.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.planner.logic.commands.module.ModuleAddCommand;
 import seedu.planner.logic.parser.Parser;
+import seedu.planner.logic.parser.ParserUtil;
 import seedu.planner.logic.parser.exceptions.ParseException;
 import seedu.planner.model.module.ModuleCode;
 
@@ -18,11 +19,7 @@ public class ModuleAddCommandParser implements Parser<ModuleAddCommand> {
     public ModuleAddCommand parse(String args) throws ParseException {
         requireNonNull(args);
 
-        try {
-            ModuleCode moduleCode = new ModuleCode(args);
-            return new ModuleAddCommand(moduleCode);
-        } catch (IllegalArgumentException e) {
-            throw new ParseException(e.getMessage());
-        }
+        ModuleCode moduleCode = ParserUtil.parseModuleCode(args);
+        return new ModuleAddCommand(moduleCode);
     }
 }

--- a/src/main/java/seedu/planner/logic/parser/module/ModuleAddCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/module/ModuleAddCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.planner.logic.parser.module;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.planner.logic.commands.module.ModuleAddCommand;
 import seedu.planner.logic.parser.Parser;
@@ -18,6 +19,11 @@ public class ModuleAddCommandParser implements Parser<ModuleAddCommand> {
     @Override
     public ModuleAddCommand parse(String args) throws ParseException {
         requireNonNull(args);
+
+        if (args.trim().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                ModuleAddCommand.MESSAGE_USAGE));
+        }
 
         ModuleCode moduleCode = ParserUtil.parseModuleCode(args);
         return new ModuleAddCommand(moduleCode);

--- a/src/main/java/seedu/planner/logic/parser/module/ModuleCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/module/ModuleCommandParser.java
@@ -1,12 +1,10 @@
 package seedu.planner.logic.parser.module;
 
-import static seedu.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.planner.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.planner.commons.core.Messages.MESSAGE_UNKNOWN_SUBCOMMAND;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.planner.logic.commands.HelpCommand;
 import seedu.planner.logic.commands.module.ModuleAddCommand;
 import seedu.planner.logic.commands.module.ModuleCommand;
 import seedu.planner.logic.commands.module.ModuleGradeCommand;
@@ -32,7 +30,7 @@ public class ModuleCommandParser implements Parser<ModuleCommand> {
     public ModuleCommand parse(String userInput) throws ParseException {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_UNKNOWN_SUBCOMMAND, ModuleCommand.MESSAGE_USAGE));
         }
 
         final String commandWord = matcher.group("commandWord");
@@ -52,7 +50,7 @@ public class ModuleCommandParser implements Parser<ModuleCommand> {
             return new ModuleGradeCommandParser().parse(arguments);
 
         default:
-            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+            throw new ParseException(String.format(MESSAGE_UNKNOWN_SUBCOMMAND, ModuleCommand.MESSAGE_USAGE));
         }
     }
 }

--- a/src/main/java/seedu/planner/logic/parser/module/ModuleGradeCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/module/ModuleGradeCommandParser.java
@@ -10,14 +10,13 @@ import seedu.planner.logic.commands.module.ModuleGradeCommand;
 import seedu.planner.logic.parser.ArgumentMultimap;
 import seedu.planner.logic.parser.ArgumentTokenizer;
 import seedu.planner.logic.parser.Parser;
+import seedu.planner.logic.parser.ParserUtil;
 import seedu.planner.logic.parser.Prefix;
 import seedu.planner.logic.parser.exceptions.ParseException;
 import seedu.planner.model.grades.LetterGrade;
 import seedu.planner.model.module.ModuleCode;
 
 public class ModuleGradeCommandParser implements Parser<ModuleGradeCommand> {
-    public static final String MESSAGE_GRADE_INVALID = "Grade is invalid: %1$s";
-
     /**
      * Returns true if none of the prefixes contains empty {@code Optional} values in the given
      * {@code ArgumentMultimap}.
@@ -42,22 +41,14 @@ public class ModuleGradeCommandParser implements Parser<ModuleGradeCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModuleGradeCommand.MESSAGE_USAGE));
         }
 
-        try {
-            ModuleCode moduleCode = new ModuleCode(argMultimap.getPreamble());
+        ModuleCode moduleCode = ParserUtil.parseModuleCode(argMultimap.getPreamble());
 
-            if (arePrefixesPresent(argMultimap, PREFIX_GRADE)) {
-                String letterGradeString = argMultimap.getValue(PREFIX_GRADE).get();
-                try {
-                    LetterGrade letterGrade = LetterGrade.valueOf(letterGradeString);
-                    return new ModuleGradeCommand(moduleCode, letterGrade);
-                } catch (IllegalArgumentException e) {
-                    throw new ParseException(String.format(MESSAGE_GRADE_INVALID, letterGradeString));
-                }
-            } else {
-                return new ModuleGradeCommand(moduleCode);
-            }
-        } catch (IllegalArgumentException e) {
-            throw new ParseException(e.getMessage());
+        if (arePrefixesPresent(argMultimap, PREFIX_GRADE)) {
+            String letterGradeString = argMultimap.getValue(PREFIX_GRADE).get();
+            LetterGrade letterGrade = ParserUtil.parseLetterGrade(letterGradeString);
+            return new ModuleGradeCommand(moduleCode, letterGrade);
+        } else {
+            return new ModuleGradeCommand(moduleCode);
         }
     }
 }

--- a/src/main/java/seedu/planner/logic/parser/module/ModuleRemoveCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/module/ModuleRemoveCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.planner.logic.parser.module;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.planner.logic.commands.module.ModuleRemoveCommand;
 import seedu.planner.logic.parser.Parser;
@@ -18,6 +19,11 @@ public class ModuleRemoveCommandParser implements Parser<ModuleRemoveCommand> {
     @Override
     public ModuleRemoveCommand parse(String args) throws ParseException {
         requireNonNull(args);
+
+        if (args.trim().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                ModuleRemoveCommand.MESSAGE_USAGE));
+        }
 
         ModuleCode moduleCode = ParserUtil.parseModuleCode(args);
         return new ModuleRemoveCommand(moduleCode);

--- a/src/main/java/seedu/planner/logic/parser/module/ModuleRemoveCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/module/ModuleRemoveCommandParser.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.planner.logic.commands.module.ModuleRemoveCommand;
 import seedu.planner.logic.parser.Parser;
+import seedu.planner.logic.parser.ParserUtil;
 import seedu.planner.logic.parser.exceptions.ParseException;
 import seedu.planner.model.module.ModuleCode;
 
@@ -18,11 +19,7 @@ public class ModuleRemoveCommandParser implements Parser<ModuleRemoveCommand> {
     public ModuleRemoveCommand parse(String args) throws ParseException {
         requireNonNull(args);
 
-        try {
-            ModuleCode moduleCode = new ModuleCode(args);
-            return new ModuleRemoveCommand(moduleCode);
-        } catch (IllegalArgumentException e) {
-            throw new ParseException(e.getMessage());
-        }
+        ModuleCode moduleCode = ParserUtil.parseModuleCode(args);
+        return new ModuleRemoveCommand(moduleCode);
     }
 }

--- a/src/main/java/seedu/planner/logic/parser/student/StudentAddCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/student/StudentAddCommandParser.java
@@ -13,6 +13,7 @@ import seedu.planner.logic.commands.student.StudentAddCommand;
 import seedu.planner.logic.parser.ArgumentMultimap;
 import seedu.planner.logic.parser.ArgumentTokenizer;
 import seedu.planner.logic.parser.Parser;
+import seedu.planner.logic.parser.ParserUtil;
 import seedu.planner.logic.parser.Prefix;
 import seedu.planner.logic.parser.exceptions.ParseException;
 import seedu.planner.model.module.ModuleCode;
@@ -55,8 +56,8 @@ public class StudentAddCommandParser implements Parser<StudentAddCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, StudentAddCommand.MESSAGE_USAGE));
         }
 
-        Name name = new Name(argMultimap.getValue(PREFIX_NAME).get());
-        Major major = new Major(argMultimap.getValue(PREFIX_MAJOR).get());
+        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        Major major = ParserUtil.parseMajor(argMultimap.getValue(PREFIX_MAJOR).get());
         TimeTableMap timeTableMap = SampleDataUtil.getSampleTimeTableMap();
         List<ModuleCode> exemptedModules = new ArrayList<>();
 

--- a/src/main/java/seedu/planner/logic/parser/student/StudentCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/student/StudentCommandParser.java
@@ -1,12 +1,10 @@
 package seedu.planner.logic.parser.student;
 
-import static seedu.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.planner.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.planner.commons.core.Messages.MESSAGE_UNKNOWN_SUBCOMMAND;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.planner.logic.commands.HelpCommand;
 import seedu.planner.logic.commands.student.StudentActiveCommand;
 import seedu.planner.logic.commands.student.StudentAddCommand;
 import seedu.planner.logic.commands.student.StudentCommand;
@@ -33,7 +31,7 @@ public class StudentCommandParser implements Parser<StudentCommand> {
     public StudentCommand parse(String userInput) throws ParseException {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_UNKNOWN_SUBCOMMAND, StudentCommand.MESSAGE_USAGE));
         }
 
         final String commandWord = matcher.group("commandWord");
@@ -56,7 +54,7 @@ public class StudentCommandParser implements Parser<StudentCommand> {
             return new StudentGradeCommand();
 
         default:
-            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+            throw new ParseException(String.format(MESSAGE_UNKNOWN_SUBCOMMAND, StudentCommand.MESSAGE_USAGE));
         }
     }
 }

--- a/src/main/java/seedu/planner/logic/parser/timetable/TimeTableActiveCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/timetable/TimeTableActiveCommandParser.java
@@ -7,7 +7,6 @@ import static seedu.planner.logic.parser.CliSyntax.PREFIX_STUDENT_YEAR;
 
 import java.util.stream.Stream;
 
-import seedu.planner.commons.core.index.Index;
 import seedu.planner.logic.commands.timetable.TimeTableActiveCommand;
 import seedu.planner.logic.parser.ArgumentMultimap;
 import seedu.planner.logic.parser.ArgumentTokenizer;
@@ -15,6 +14,7 @@ import seedu.planner.logic.parser.Parser;
 import seedu.planner.logic.parser.ParserUtil;
 import seedu.planner.logic.parser.Prefix;
 import seedu.planner.logic.parser.exceptions.ParseException;
+import seedu.planner.model.time.DegreeYear;
 import seedu.planner.model.time.Semester;
 import seedu.planner.model.time.SemesterYear;
 import seedu.planner.model.time.StudentSemester;
@@ -53,19 +53,11 @@ public class TimeTableActiveCommandParser implements Parser<TimeTableActiveComma
                 TimeTableActiveCommand.MESSAGE_USAGE));
         }
 
-        Index index;
-        Semester sem;
-
-        try {
-            index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_STUDENT_YEAR).get());
-            sem = ParserUtil.parseSemester(argMultimap.getValue(PREFIX_STUDENT_SEM).get());
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                TimeTableActiveCommand.MESSAGE_USAGE), pe);
-        }
+        final DegreeYear year = ParserUtil.parseYear(argMultimap.getValue(PREFIX_STUDENT_YEAR).get());
+        final Semester sem = ParserUtil.parseSemester(argMultimap.getValue(PREFIX_STUDENT_SEM).get());
 
         SemesterYear semesterYear = new SemesterYear(sem, 0); // TODO: input academic year
-        StudentSemester studentSemester = new StudentSemester(semesterYear, index.getOneBased());
+        StudentSemester studentSemester = new StudentSemester(semesterYear, year.getYear());
         return new TimeTableActiveCommand(studentSemester);
     }
 }

--- a/src/main/java/seedu/planner/logic/parser/timetable/TimeTableAddCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/timetable/TimeTableAddCommandParser.java
@@ -7,7 +7,6 @@ import static seedu.planner.logic.parser.CliSyntax.PREFIX_STUDENT_YEAR;
 
 import java.util.stream.Stream;
 
-import seedu.planner.commons.core.index.Index;
 import seedu.planner.logic.commands.timetable.TimeTableAddCommand;
 import seedu.planner.logic.parser.ArgumentMultimap;
 import seedu.planner.logic.parser.ArgumentTokenizer;
@@ -15,6 +14,7 @@ import seedu.planner.logic.parser.Parser;
 import seedu.planner.logic.parser.ParserUtil;
 import seedu.planner.logic.parser.Prefix;
 import seedu.planner.logic.parser.exceptions.ParseException;
+import seedu.planner.model.time.DegreeYear;
 import seedu.planner.model.time.Semester;
 import seedu.planner.model.time.SemesterYear;
 import seedu.planner.model.time.StudentSemester;
@@ -52,19 +52,11 @@ public class TimeTableAddCommandParser implements Parser<TimeTableAddCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TimeTableAddCommand.MESSAGE_USAGE));
         }
 
-        Index index;
-        Semester sem;
-
-        try {
-            index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_STUDENT_YEAR).get());
-            sem = ParserUtil.parseSemester(argMultimap.getValue(PREFIX_STUDENT_SEM).get());
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TimeTableAddCommand.MESSAGE_USAGE),
-                pe);
-        }
+        final DegreeYear year = ParserUtil.parseYear(argMultimap.getValue(PREFIX_STUDENT_YEAR).get());
+        final Semester sem = ParserUtil.parseSemester(argMultimap.getValue(PREFIX_STUDENT_SEM).get());
 
         SemesterYear semesterYear = new SemesterYear(sem, 0); // TODO: input academic year
-        StudentSemester studentSemester = new StudentSemester(semesterYear, index.getOneBased());
+        StudentSemester studentSemester = new StudentSemester(semesterYear, year.getYear());
         return new TimeTableAddCommand(studentSemester);
     }
 }

--- a/src/main/java/seedu/planner/logic/parser/timetable/TimeTableCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/timetable/TimeTableCommandParser.java
@@ -1,12 +1,10 @@
 package seedu.planner.logic.parser.timetable;
 
-import static seedu.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.planner.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.planner.commons.core.Messages.MESSAGE_UNKNOWN_SUBCOMMAND;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.planner.logic.commands.HelpCommand;
 import seedu.planner.logic.commands.student.StudentRemoveCommand;
 import seedu.planner.logic.commands.timetable.TimeTableActiveCommand;
 import seedu.planner.logic.commands.timetable.TimeTableAddCommand;
@@ -32,7 +30,7 @@ public class TimeTableCommandParser implements Parser<TimeTableCommand> {
     public TimeTableCommand parse(String userInput) throws ParseException {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_UNKNOWN_SUBCOMMAND, TimeTableCommand.MESSAGE_USAGE));
         }
 
         final String commandWord = matcher.group("commandWord");
@@ -52,7 +50,7 @@ public class TimeTableCommandParser implements Parser<TimeTableCommand> {
             return new TimeTableListCommand();
 
         default:
-            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+            throw new ParseException(String.format(MESSAGE_UNKNOWN_SUBCOMMAND, TimeTableCommand.MESSAGE_USAGE));
         }
     }
 }

--- a/src/main/java/seedu/planner/logic/parser/timetable/TimeTableRemoveCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/timetable/TimeTableRemoveCommandParser.java
@@ -7,7 +7,6 @@ import static seedu.planner.logic.parser.CliSyntax.PREFIX_STUDENT_YEAR;
 
 import java.util.stream.Stream;
 
-import seedu.planner.commons.core.index.Index;
 import seedu.planner.logic.commands.timetable.TimeTableRemoveCommand;
 import seedu.planner.logic.parser.ArgumentMultimap;
 import seedu.planner.logic.parser.ArgumentTokenizer;
@@ -15,6 +14,7 @@ import seedu.planner.logic.parser.Parser;
 import seedu.planner.logic.parser.ParserUtil;
 import seedu.planner.logic.parser.Prefix;
 import seedu.planner.logic.parser.exceptions.ParseException;
+import seedu.planner.model.time.DegreeYear;
 import seedu.planner.model.time.Semester;
 import seedu.planner.model.time.SemesterYear;
 import seedu.planner.model.time.StudentSemester;
@@ -53,19 +53,11 @@ public class TimeTableRemoveCommandParser implements Parser<TimeTableRemoveComma
                 TimeTableRemoveCommand.MESSAGE_USAGE));
         }
 
-        Index index;
-        Semester sem;
-
-        try {
-            index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_STUDENT_YEAR).get());
-            sem = ParserUtil.parseSemester(argMultimap.getValue(PREFIX_STUDENT_SEM).get());
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                TimeTableRemoveCommand.MESSAGE_USAGE), pe);
-        }
+        final DegreeYear year = ParserUtil.parseYear(argMultimap.getValue(PREFIX_STUDENT_YEAR).get());
+        final Semester sem = ParserUtil.parseSemester(argMultimap.getValue(PREFIX_STUDENT_SEM).get());
 
         SemesterYear semesterYear = new SemesterYear(sem, 0); // TODO: input academic year
-        StudentSemester studentSemester = new StudentSemester(semesterYear, index.getOneBased());
+        StudentSemester studentSemester = new StudentSemester(semesterYear, year.getYear());
         return new TimeTableRemoveCommand(studentSemester);
     }
 }

--- a/src/main/java/seedu/planner/model/grades/LetterGrade.java
+++ b/src/main/java/seedu/planner/model/grades/LetterGrade.java
@@ -1,37 +1,64 @@
 package seedu.planner.model.grades;
 
+import static seedu.planner.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Arrays;
 import java.util.OptionalDouble;
+import java.util.stream.Collectors;
 
 public enum LetterGrade {
-    A_PLUS(5.0),
-    A(5.0),
-    A_MINUS(4.5),
-    B_PLUS(4.0),
-    B(3.5),
-    B_MINUS(3.0),
-    C_PLUS(2.5),
-    C(2.0),
-    D_PLUS(1.5),
-    D(1.0),
-    F(0.0),
-    CS,
-    CU,
-    W,
-    EXE;
+    A_PLUS(5.0, "A+"),
+    A(5.0, "A"),
+    A_MINUS(4.5, "A-"),
+    B_PLUS(4.0, "B+"),
+    B(3.5, "B"),
+    B_MINUS(3.0, "B-"),
+    C_PLUS(2.5, "C+"),
+    C(2.0, "C-"),
+    D_PLUS(1.5, "D+"),
+    D(1.0, "D"),
+    F(0.0, "F"),
+    CS("CS"),
+    CU("CU"),
+    W("W"),
+    EXE("EXE");
 
     public static final String MESSAGE_CONSTRAINTS =
-        "Letter grades must be one of the following: A+, A, A-, B+, B, B-, C+, C, D+, D, F, CS, CU, W, EXE";
+        "Letter grades must be one of the following: " + getConcatenatedString();
 
     public final OptionalDouble points;
     public final boolean isSu;
+    private final String inputName;
 
-    LetterGrade(double points) {
+    LetterGrade(double points, String inputName) {
         this.points = OptionalDouble.of(points);
+        this.inputName = inputName;
         this.isSu = false;
     }
 
-    LetterGrade() {
+    LetterGrade(String inputName) {
         this.points = OptionalDouble.empty();
+        this.inputName = inputName;
         this.isSu = true;
+    }
+
+    private static String getConcatenatedString() {
+        return Arrays.stream(LetterGrade.values()).map(LetterGrade::toString)
+            .collect(Collectors.joining(", "));
+    }
+
+    public static LetterGrade fromInputName(String letterGrade) {
+        requireAllNonNull(letterGrade);
+        for (LetterGrade grade : LetterGrade.values()) {
+            if (grade.inputName.equals(letterGrade)) {
+                return grade;
+            }
+        }
+        throw new IllegalArgumentException(String.format("Invalid input name for LetterGrade: %1$s", letterGrade));
+    }
+
+    @Override
+    public String toString() {
+        return inputName;
     }
 }

--- a/src/main/java/seedu/planner/model/grades/LetterGrade.java
+++ b/src/main/java/seedu/planner/model/grades/LetterGrade.java
@@ -19,6 +19,9 @@ public enum LetterGrade {
     W,
     EXE;
 
+    public static final String MESSAGE_CONSTRAINTS =
+        "Letter grades must be one of the following: A+, A, A-, B+, B, B-, C+, C, D+, D, F, CS, CU, W, EXE";
+
     public final OptionalDouble points;
     public final boolean isSu;
 

--- a/src/main/java/seedu/planner/model/time/DegreeYear.java
+++ b/src/main/java/seedu/planner/model/time/DegreeYear.java
@@ -1,0 +1,30 @@
+package seedu.planner.model.time;
+
+import seedu.planner.commons.core.index.Index;
+
+public class DegreeYear {
+    private int year;
+
+    /**
+     * Index can only be created by calling {@link Index#fromZeroBased(int)} or
+     * {@link Index#fromOneBased(int)}.
+     */
+    public DegreeYear(int year) {
+        if (year < 0) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        this.year = year;
+    }
+
+    public int getYear() {
+        return year;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+            || (other instanceof DegreeYear // instanceof handles nulls
+            && year == ((DegreeYear) other).year); // state check
+    }
+}

--- a/src/main/java/seedu/planner/model/time/Semester.java
+++ b/src/main/java/seedu/planner/model/time/Semester.java
@@ -1,20 +1,24 @@
 package seedu.planner.model.time;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 public enum Semester {
     ONE("Semester 1"),
     TWO("Semester 2"),
     SPECIAL_ONE("Special Semester 1"),
     SPECIAL_TWO("Special Semester 2");
 
-    public static final String MESSAGE_CONSTRAINTS = "Semester can be one of the following: "
-        + Semester.values().toString();
-    private String name;
+    public static final String MESSAGE_CONSTRAINTS = "Semester must be one of the following: "
+        + getConcatenatedString();
+    private final String fullName;
 
-    Semester(String name) {
-        this.name = name;
+    Semester(String fullName) {
+        this.fullName = fullName;
     }
 
-    public String getAction() {
-        return this.name;
+    private static String getConcatenatedString() {
+        return Arrays.stream(Semester.values()).map(Semester::toString)
+            .collect(Collectors.joining(", "));
     }
 }


### PR DESCRIPTION
Invalid inputs for the `student`, `timetable`, `module` and `exempt` commands and sub-commands no longer cause uncaught exceptions to be thrown. More helpful error messages are also shown on invalid input.