### PR TITLE
Add tests for commands and parsers

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -119,8 +119,8 @@ These are parameters that are commonly used in commands available in NUSModPlnr.
 ** Must be alphanumeric, spaces are allowed
 * `SEM` - an academic semester
 ** Must be one of the following: `ONE`, `TWO`, `SPECIAL_ONE`, `SPECIAL_TWO`
-* `YEAR` - a year of study (e.g. Year 1, 2, 3, 4...)
-** Must be a non-negative integer
+* `YEAR` - a year of study (e.g. Year 1, 2, 3, 4, 5, 6)
+** Must be a non-negative integer from 1 to 6
 * `GRADE` a letter grade for a module
 ** Must be one of the following: `A+`, `A`, `A-`, `B+`, `B`, `B-`, `C+`, `C`, `D+`, `D`, `F`, `CS`, `CU`, `W`, `EXE`
 ====
@@ -148,7 +148,7 @@ Format: `exit`
 
 The following commands below are part of the application's *Student Management*, which allow you manage the students _which include you_ for the academic planning. You are highly encouraged to use this *Student Management* feature to explore different academic plans.
 
-When managing students, you will be able to see the *Student View Screen* (_Figure 3. below_).
+When managing students, you will be able to see the *Student View Screen* (_Figure 2. below_).
 
 .Student List View
 image::StudentList.png[width="600", align="left"]
@@ -158,7 +158,6 @@ image::StudentList.png[width="600", align="left"]
 You can use this command to add a <<student-management,student>> to the student list.
 
 [NOTE]
-
 You may not add multiple students with the same name.
 
 Format: `student add n/NAME major/MAJOR`
@@ -171,6 +170,16 @@ Example:
 
 You can use this command to remove the <<student-management,student>> with the number `INDEX` from the student list.
 
+[NOTE]
+When you use this command on the same student as the student you are currently selecting (see the <<student-active-command,`student active`>> command),
+the timetable you have currently selected (see the <<timetable-active-command,`timetable active`>> command) will be deselected (if a timetable was selected).
+
+[NOTE]
+To work on another student's timetable, first use the  <<student-active-command,`student active`>> command to select a student, then
+use the <<timetable-active-command,`timetable active`>> command to select another timetable. +
+You may see the list of students using the <<student-list-command,`student list`>> command, and
+the list of timetables of a selected student has using the <<timetable-list-command,`timetable list`>> command.
+
 Format: `student remove INDEX`
 
 Example:
@@ -182,12 +191,18 @@ Example:
 
 You can use this command to select the <<student-management,student>> with the number `INDEX` from the student list.
 
+[NOTE]
+When you use this command, any timetable you have selected (see the <<timetable-active-command,`timetable active`>> command) will be deselected.
+To work on the newly selected student's timetable, use the <<timetable-active-command,`timetable active`>> command to select a timetable. +
+You may see the list of timetables the selected student has using the <<timetable-list-command,`timetable list`>> command.
+
 Format: `student active INDEX`
 
 Example:
 
 * `student active 1`
 
+[[student-list-command]]
 ==== Viewing the student list: `student list`
 
 You can use this command to display a numbered list of students in the student list (if populated).
@@ -241,7 +256,7 @@ Examples:
 
 The following commands below are part of the application's *Timetable Management*, which allow you manage the timetables of your academic plan.
 
-When managing your <<timetable-management,timetable>>, you will be able to see the *Timetable View Screen* (_Figure 4. below_).
+When managing your <<timetable-management,timetable>>, you will be able to see the *Timetable View Screen* (_Figure 3. below_).
 
 .Timetable List View
 image::TimeTableList.png[width="600", align="left"]
@@ -254,11 +269,9 @@ All the following commands require a <<student-management,student>> to be select
 You can use this command to add a <<timetable-management,timetable>> to the specified <<common-parameter-list,semester>> of the selected <<student-management,student>> (see the <<student-active-command,`student active`>> command).
 
 [NOTE]
-This command requires the `YEAR` and `SEM` to conform to the parameter syntax in <<common-parameter-list,*Common Parameters*>>.
-[TIP]
-While any non-negative degree year for the `YEAR` parameter is allowed (e.g. 0, 1, 999999999), try to use reasonable values for your academic planning.
-[TIP]
-The `YEAR` parameter can take the value of `0`. You can use this to add modules you have taken before entering NUS which you do not want to mark as exempt (using the <<exempt-add-command,`exempt add`>> command).
+This command requires the `YEAR` and `SEM` to conform to the parameter syntax in <<common-parameter-list,*Common Parameters*>>. +
+The `YEAR` parameter must be a valid degree year (from 1 to 6, inclusive). +
+The `SEM` parameter must be one of the following: `ONE`, `TWO`, `SPECIAL_ONE`, `SPECIAL_TWO`.
 
 Format: `timetable add year/YEAR sem/SEM`
 
@@ -270,6 +283,11 @@ Example:
 
 You can use this command to remove a <<timetable-management,timetable>> to the specified <<common-parameter-list,semester>> of the selected <<student-management,student>> (see the <<student-active-command,`student active`>> command).
 
+[NOTE]
+This command requires the `YEAR` and `SEM` to conform to the parameter syntax in <<common-parameter-list,*Common Parameters*>>. +
+The `YEAR` parameter must be a valid degree year (from 1 to 6, inclusive). +
+The `SEM` parameter must be one of the following: `ONE`, `TWO`, `SPECIAL_ONE`, `SPECIAL_TWO`.
+
 Format: `timetable remove year/YEAR sem/SEM`
 
 Example:
@@ -280,12 +298,19 @@ Example:
 ==== Selecting a timetable: `timetable active`
 
 You can use this command to select a <<timetable-management,timetable>> of the specified <<common-parameter-list,semester>> of the selected <<student-management,student>> (see the <<student-active-command,`student active`>> command).
+
+[NOTE]
+This command requires the `YEAR` and `SEM` to conform to the parameter syntax in <<common-parameter-list,*Common Parameters*>>. +
+The `YEAR` parameter must be a valid degree year (from 1 to 6, inclusive). +
+The `SEM` parameter must be one of the following: `ONE`, `TWO`, `SPECIAL_ONE`, `SPECIAL_TWO`.
+
 Format: `timetable active year/YEAR sem/SEM`
 
 Example:
 
 * `timetable active year/2 sem/ONE`
 
+[[timetable-list-command]]
 ==== Viewing the timetable list: `timetable list`
 
 You can use this command to list all the <<timetable-management,timetables>>  of the selected <<student-management,student>> (see the <<student-active-command,`student active`>> command).
@@ -468,6 +493,11 @@ Example:
 
 The following commands below are part of the application's *Grade Management*, which allow you to manage and view your grades to see modules affected in your academic plan.
 
+[TIP]
+The same module can be added into multiple timetables of the same student. Therefore, each enrollment (one per semester) of the same module can have a separate grade. +
+For example, it is possible for you to enroll in the module `CS2040` during `year/1 sem/ONE` and then `year/1 sem/TWO`. +
+You may refer to <<timetable-management,*Timetable Management*>> to see how you can use timetables.
+
 ==== Managing a module's grade: `module grade`
 
 You can use this command to display the <<grade-management,grade>> of the specified module.
@@ -494,10 +524,19 @@ Example:
 
 ==== Viewing a student's grade: `student grade`
 
-You can use this command to display  the cumulative grade of the selected student (see the <<student-active-command,`student active`>> command).
+You can use this command to display the <<cap,Cumulative Average Point>> of the selected student (see the <<student-active-command,`student active`>> command). +
+Other statistics such as the number of modules declared as <<su,Satisfactory/Unsatisfactory>> are also shown. +
+You may also see a list of modules taken and their grades.
 
 [NOTE]
 This command requires a student to be selected (using the <<student-active-command,`student active`>> command).
+[TIP]
+Use the <<module-grade-command,`module grade`>> command to set the grade of modules in the currently selected timetable of a student.
+[TIP]
+The same module can be added into multiple timetables of the same student. Refer to <<timetable-management,*Timetable Management*>> to see how you can use timetables.
+[TIP]
+Use this command to be informed of your academic progress and to plan ahead for difficult modules.
+
 
 Format: `student grade`
 
@@ -571,6 +610,12 @@ Refers to one of academic specialisations students can optionally read in NUS.
 
 [[timetable]] Timetable::
 Refers to the module timetable that students will go for classes in NUS.
+
+[[cap]] Cumulative Average Point::
+Refers to the average grade points of all modules taken, weighted by the number of module credits for each counted module.
+
+[[su]] Satisfactory/Unsatisfactory::
+Refers to a module not being assigned grade points, and thus not affecting a student's Cumulative Average Point.
 
 == Command & Features Summary
 

--- a/src/main/java/seedu/planner/commons/core/Messages.java
+++ b/src/main/java/seedu/planner/commons/core/Messages.java
@@ -8,9 +8,10 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_UNKNOWN_SUBCOMMAND = "Unknown subcommand\n%1$s";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format!\n%1$s";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
 
     public static final String MESSAGE_NO_STUDENT_ACTIVE = "No student is active";
     public static final String MESSAGE_NO_TIMETABLE_ACTIVE = "No timetable is active";
+    public static final String MESSAGE_INVALID_SEMESTER = "Semester does not exist in list of timetables: %1$s";
 }

--- a/src/main/java/seedu/planner/logic/commands/exemptions/ExemptAddCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/exemptions/ExemptAddCommand.java
@@ -3,6 +3,8 @@ package seedu.planner.logic.commands.exemptions;
 import static java.util.Objects.requireNonNull;
 import static seedu.planner.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Objects;
+
 import seedu.planner.commons.core.Messages;
 import seedu.planner.logic.commands.CommandResult;
 import seedu.planner.logic.commands.exceptions.CommandException;
@@ -35,7 +37,7 @@ public class ExemptAddCommand extends ExemptCommand {
     }
 
     /**
-     * Generates a command execution error message due to the given (@code moduleCode) being invalid.
+     * Generates a command execution error message due to the given {@code moduleCode} being invalid.
      */
     private String generateModuleDoesNotExist(ModuleCode moduleCode) {
         return String.format(MESSAGE_ADD_MODULE_INVALID, moduleCode.value);
@@ -43,7 +45,7 @@ public class ExemptAddCommand extends ExemptCommand {
 
 
     /**
-     * Generates a command execution error message due to the given (@code moduleCode) already being present
+     * Generates a command execution error message due to the given {@code moduleCode} already being present
      * in the list of exempted modules of the selected student.
      */
     private String generateDuplicateMessage(ModuleCode moduleCode) {
@@ -51,7 +53,7 @@ public class ExemptAddCommand extends ExemptCommand {
     }
 
     /**
-     * Generates a command execution success message for adding the (@code moduleCode)
+     * Generates a command execution success message for adding the {@code moduleCode}
      * to the list of exempted modules of the selected student.
      */
     private String generateSuccessMessage(ModuleCode moduleCode) {
@@ -79,6 +81,23 @@ public class ExemptAddCommand extends ExemptCommand {
 
         model.addExemptedModule(moduleCode);
         return new CommandResult(generateSuccessMessage(moduleCode));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ExemptAddCommand that = (ExemptAddCommand) o;
+        return moduleCode.equals(that.moduleCode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(moduleCode);
     }
 }
 //@@author

--- a/src/main/java/seedu/planner/logic/commands/exemptions/ExemptCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/exemptions/ExemptCommand.java
@@ -17,7 +17,7 @@ public abstract class ExemptCommand extends Command {
 
 
     /**
-     * Returns the (@code COMMAND_NAME) concatenated with the name of the input (@code subCommand).
+     * Returns the {@code COMMAND_NAME} concatenated with the name of the input {@code subCommand}.
      * @param subCommand
      * @return Qualified name
      */

--- a/src/main/java/seedu/planner/logic/commands/exemptions/ExemptListCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/exemptions/ExemptListCommand.java
@@ -2,6 +2,8 @@ package seedu.planner.logic.commands.exemptions;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Objects;
+
 import javafx.collections.ObservableList;
 import seedu.planner.commons.core.Messages;
 import seedu.planner.logic.commands.CommandResult;
@@ -50,6 +52,22 @@ public class ExemptListCommand extends ExemptCommand {
         }
 
         return new CommandResult(generateSuccessMessage(model.getExemptedModulesList()));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash();
     }
 }
 //@@author

--- a/src/main/java/seedu/planner/logic/commands/exemptions/ExemptRemoveCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/exemptions/ExemptRemoveCommand.java
@@ -3,6 +3,8 @@ package seedu.planner.logic.commands.exemptions;
 import static java.util.Objects.requireNonNull;
 import static seedu.planner.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Objects;
+
 import seedu.planner.commons.core.Messages;
 import seedu.planner.logic.commands.CommandResult;
 import seedu.planner.logic.commands.exceptions.CommandException;
@@ -34,7 +36,7 @@ public class ExemptRemoveCommand extends ExemptCommand {
     }
 
     /**
-     * Generates a command execution error message due to the given (@code moduleCode) being absent
+     * Generates a command execution error message due to the given {@code moduleCode} being absent
      * from the in the list of exempted modules of the selected student.
      */
     private String generateFailureMessage(ModuleCode moduleCode) {
@@ -42,7 +44,7 @@ public class ExemptRemoveCommand extends ExemptCommand {
     }
 
     /**
-     * Generates a command execution success message for removing the given (@code moduleCode)
+     * Generates a command execution success message for removing the given {@code moduleCode}
      * from the list of exempted modules of the selected student.
      */
     private String generateSuccessMessage(ModuleCode moduleCode) {
@@ -65,6 +67,23 @@ public class ExemptRemoveCommand extends ExemptCommand {
 
         model.removeExemptedModule(moduleCode);
         return new CommandResult(generateSuccessMessage(moduleCode));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ExemptRemoveCommand that = (ExemptRemoveCommand) o;
+        return moduleCode.equals(that.moduleCode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(moduleCode);
     }
 }
 //@@author

--- a/src/main/java/seedu/planner/logic/commands/lessons/LessonRemoveCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/lessons/LessonRemoveCommand.java
@@ -45,7 +45,7 @@ public class LessonRemoveCommand extends LessonCommand {
         List<Lesson> lastShownList = model.getLessons();
 
         if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
         }
 
         Lesson removedLesson = lastShownList.get(index.getZeroBased());

--- a/src/main/java/seedu/planner/logic/commands/major/MajorCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/major/MajorCommand.java
@@ -16,7 +16,7 @@ public abstract class MajorCommand extends Command {
 
 
     /**
-     * Returns the (@code COMMAND_NAME) concatenated with the name of the input (@code subCommand).
+     * Returns the {@code COMMAND_NAME} concatenated with the name of the input {@code subCommand}.
      * @param subCommand
      * @return Qualified name
      */

--- a/src/main/java/seedu/planner/logic/commands/module/ModuleAddCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/module/ModuleAddCommand.java
@@ -3,6 +3,7 @@ package seedu.planner.logic.commands.module;
 import static java.util.Objects.requireNonNull;
 import static seedu.planner.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import seedu.planner.commons.core.Messages;
@@ -40,7 +41,7 @@ public class ModuleAddCommand extends ModuleCommand {
     }
 
     /**
-     * Generates a command execution error message due to the given (@code moduleCode) being invalid.
+     * Generates a command execution error message due to the given {@code moduleCode} being invalid.
      */
     private String generateModuleDoesNotExists(ModuleCode moduleCode) {
         return String.format(MESSAGE_ADD_MODULE_INVALID, moduleCode.value);
@@ -48,7 +49,7 @@ public class ModuleAddCommand extends ModuleCommand {
 
 
     /**
-     * Generates a command execution error message due to the given (@code moduleCode) already being present
+     * Generates a command execution error message due to the given {@code moduleCode} already being present
      * in the selected timetable of the selected student.
      */
     private String generateDuplicateMessage(ModuleCode moduleCode) {
@@ -56,7 +57,7 @@ public class ModuleAddCommand extends ModuleCommand {
     }
 
     /**
-     * Generates a command execution success message for adding the given (@code moduleCode)
+     * Generates a command execution success message for adding the given {@code moduleCode}
      * to the selected timetable of the selected student.
      */
     private String generateSuccessMessage(ModuleCode moduleCode) {
@@ -92,6 +93,23 @@ public class ModuleAddCommand extends ModuleCommand {
         Enrollment enrollment = new Enrollment(moduleCode, Optional.empty(), module.getModuleCredit());
         model.addEnrollment(enrollment);
         return new CommandResult(generateSuccessMessage(moduleCode));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ModuleAddCommand that = (ModuleAddCommand) o;
+        return moduleCode.equals(that.moduleCode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(moduleCode);
     }
 }
 //@@author

--- a/src/main/java/seedu/planner/logic/commands/module/ModuleCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/module/ModuleCommand.java
@@ -17,7 +17,7 @@ public abstract class ModuleCommand extends Command {
 
 
     /**
-     * Returns the (@code COMMAND_NAME) concatenated with the name of the input (@code subCommand).
+     * Returns the {@code COMMAND_NAME} concatenated with the name of the input {@code subCommand}.
      * @param subCommand
      * @return Qualified name
      */

--- a/src/main/java/seedu/planner/logic/commands/module/ModuleGradeCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/module/ModuleGradeCommand.java
@@ -38,14 +38,14 @@ public abstract class ModuleGradeCommand extends ModuleCommand {
     }
 
     /**
-     * Generates a command execution error message due to the given (@code moduleCode) being invalid.
+     * Generates a command execution error message due to the given {@code moduleCode} being invalid.
      */
     private String generateModuleInvalidMessage(ModuleCode moduleCode) {
         return String.format(MESSAGE_MODULE_INVALID, moduleCode.value);
     }
 
     /**
-     * Generates a command execution error message due to the given (@code moduleCode) being absent from
+     * Generates a command execution error message due to the given {@code moduleCode} being absent from
      * the active student.
      */
     private String generateModuleNotEnrolledMessage(ModuleCode moduleCode) {
@@ -53,7 +53,7 @@ public abstract class ModuleGradeCommand extends ModuleCommand {
     }
 
     /**
-     * Validate that a student and timetable are selected, and that the requested (@code moduleCode)
+     * Validate that a student and timetable are selected, and that the requested {@code moduleCode}
      * is valid and is enrolled in the current timetable.
      */
     protected void validate(Model model) throws CommandException {

--- a/src/main/java/seedu/planner/logic/commands/module/ModuleGradeSetCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/module/ModuleGradeSetCommand.java
@@ -3,6 +3,8 @@ package seedu.planner.logic.commands.module;
 import static java.util.Objects.requireNonNull;
 import static seedu.planner.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Objects;
+
 import seedu.planner.logic.commands.CommandResult;
 import seedu.planner.logic.commands.exceptions.CommandException;
 import seedu.planner.model.Model;
@@ -29,8 +31,8 @@ public class ModuleGradeSetCommand extends ModuleGradeCommand {
     }
 
     /**
-     * Generates a command execution success message for setting the enrollment with the given (@code moduleCode)
-     * to have the specified (@code grade).
+     * Generates a command execution success message for setting the enrollment with the given {@code moduleCode}
+     * to have the specified {@code grade}.
      */
     private String generateSetGradeSuccessMessage(ModuleCode moduleCode, LetterGrade grade) {
         return String.format(MESSAGE_SET_GRADE_SUCCESS, moduleCode.value, grade);
@@ -43,6 +45,23 @@ public class ModuleGradeSetCommand extends ModuleGradeCommand {
 
         model.setModuleGrade(moduleCode, new Grade(letterGrade, false));
         return new CommandResult(generateSetGradeSuccessMessage(moduleCode, letterGrade));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ModuleGradeSetCommand that = (ModuleGradeSetCommand) o;
+        return letterGrade == that.letterGrade;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(letterGrade);
     }
 }
 //@@author

--- a/src/main/java/seedu/planner/logic/commands/module/ModuleGradeViewCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/module/ModuleGradeViewCommand.java
@@ -2,6 +2,7 @@ package seedu.planner.logic.commands.module;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import seedu.planner.logic.commands.CommandResult;
@@ -23,7 +24,7 @@ public class ModuleGradeViewCommand extends ModuleGradeCommand {
     }
 
     /**
-     * Generates a command execution success message for displaying the enrollment with the given (@code moduleCode)
+     * Generates a command execution success message for displaying the enrollment with the given {@code moduleCode}
      * with a pending grade.
      */
     private String generateViewGradeSuccessMessage(ModuleCode moduleCode) {
@@ -31,8 +32,8 @@ public class ModuleGradeViewCommand extends ModuleGradeCommand {
     }
 
     /**
-     * Generates a command execution success message for displaying the enrollment with the given (@code moduleCode)
-     * with a (@code grade).
+     * Generates a command execution success message for displaying the enrollment with the given {@code moduleCode}
+     * with a {@code grade}.
      */
     private String generateViewGradeSuccessMessage(ModuleCode moduleCode, Grade grade) {
         return String.format(MESSAGE_VIEW_GRADE_SUCCESS, moduleCode.value, grade);
@@ -49,6 +50,23 @@ public class ModuleGradeViewCommand extends ModuleGradeCommand {
         } else {
             return new CommandResult(generateViewGradeSuccessMessage(moduleCode));
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ModuleGradeViewCommand that = (ModuleGradeViewCommand) o;
+        return moduleCode.equals(that.moduleCode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(moduleCode);
     }
 }
 //@@author

--- a/src/main/java/seedu/planner/logic/commands/module/ModuleListCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/module/ModuleListCommand.java
@@ -2,6 +2,8 @@ package seedu.planner.logic.commands.module;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Objects;
+
 import javafx.collections.ObservableList;
 import seedu.planner.commons.core.Messages;
 import seedu.planner.logic.commands.CommandResult;
@@ -54,6 +56,22 @@ public class ModuleListCommand extends ModuleCommand {
         }
 
         return new CommandResult(generateSuccessMessage(model.getEnrolledModuleCodes()));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash();
     }
 }
 //@@author

--- a/src/main/java/seedu/planner/logic/commands/module/ModuleRemoveCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/module/ModuleRemoveCommand.java
@@ -3,6 +3,8 @@ package seedu.planner.logic.commands.module;
 import static java.util.Objects.requireNonNull;
 import static seedu.planner.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Objects;
+
 import seedu.planner.commons.core.Messages;
 import seedu.planner.logic.commands.CommandResult;
 import seedu.planner.logic.commands.exceptions.CommandException;
@@ -34,7 +36,7 @@ public class ModuleRemoveCommand extends ModuleCommand {
     }
 
     /**
-     * Generates a command execution error message due to the given (@code moduleCode) being absent
+     * Generates a command execution error message due to the given {@code moduleCode} being absent
      * from the selected timetable of the selected student.
      */
     private String generateFailureMessage(ModuleCode moduleCode) {
@@ -42,7 +44,7 @@ public class ModuleRemoveCommand extends ModuleCommand {
     }
 
     /**
-     * Generates a command execution success message for removing the given (@code moduleCode)
+     * Generates a command execution success message for removing the given {@code moduleCode}
      * from the selected timetable of the selected student.
      */
     private String generateSuccessMessage(ModuleCode moduleCode) {
@@ -69,6 +71,23 @@ public class ModuleRemoveCommand extends ModuleCommand {
         model.removeEnrollment(moduleCode);
 
         return new CommandResult(generateSuccessMessage(moduleCode));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ModuleRemoveCommand that = (ModuleRemoveCommand) o;
+        return moduleCode.equals(that.moduleCode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(moduleCode);
     }
 }
 //@@author

--- a/src/main/java/seedu/planner/logic/commands/specialisation/SpecialisationCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/specialisation/SpecialisationCommand.java
@@ -26,7 +26,7 @@ public abstract class SpecialisationCommand extends Command {
 
 
     /**
-     * Returns the (@code COMMAND_NAME) concatenated with the name of the input (@code subCommand).
+     * Returns the {@code COMMAND_NAME} concatenated with the name of the input {@code subCommand}.
      * @param subCommand
      * @return Qualified name
      */

--- a/src/main/java/seedu/planner/logic/commands/student/StudentActiveCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/student/StudentActiveCommand.java
@@ -3,6 +3,8 @@ package seedu.planner.logic.commands.student;
 import static java.util.Objects.requireNonNull;
 import static seedu.planner.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Objects;
+
 import javafx.collections.ObservableList;
 import seedu.planner.commons.core.Messages;
 import seedu.planner.commons.core.index.Index;
@@ -34,7 +36,7 @@ public class StudentActiveCommand extends StudentCommand {
     }
 
     /**
-     * Generates a command execution success message for selecting the given (@code student).
+     * Generates a command execution success message for selecting the given {@code student}.
      */
     private String generateSuccessMessage(Student student) {
         return String.format(MESSAGE_ACTIVE_STUDENT_SUCCESS, student);
@@ -53,13 +55,30 @@ public class StudentActiveCommand extends StudentCommand {
         ObservableList<Student> lastShownList = model.getStudentList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
         }
 
         Student student = lastShownList.get(index.getZeroBased());
         model.activateStudent(student);
 
         return new CommandResult(generateSuccessMessage(student));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        StudentActiveCommand that = (StudentActiveCommand) o;
+        return index.equals(that.index);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(index);
     }
 }
 //@@author

--- a/src/main/java/seedu/planner/logic/commands/student/StudentAddCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/student/StudentAddCommand.java
@@ -5,6 +5,8 @@ import static seedu.planner.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.planner.logic.parser.CliSyntax.PREFIX_MAJOR;
 import static seedu.planner.logic.parser.CliSyntax.PREFIX_NAME;
 
+import java.util.Objects;
+
 import seedu.planner.logic.commands.CommandResult;
 import seedu.planner.logic.commands.exceptions.CommandException;
 import seedu.planner.model.Model;
@@ -38,7 +40,7 @@ public class StudentAddCommand extends StudentCommand {
     }
 
     /**
-     * Generates a command execution success message for adding the (@addedStudent) to the list of students.
+     * Generates a command execution success message for adding the {@code addedStudent} to the list of students.
      */
     private String generateSuccessMessage(Student addedStudent) {
         return String.format(MESSAGE_ADD_STUDENT_SUCCESS, addedStudent);
@@ -60,6 +62,23 @@ public class StudentAddCommand extends StudentCommand {
         model.addStudent(student);
 
         return new CommandResult(generateSuccessMessage(student));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        StudentAddCommand that = (StudentAddCommand) o;
+        return student.equals(that.student);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(student);
     }
 }
 //@@author

--- a/src/main/java/seedu/planner/logic/commands/student/StudentCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/student/StudentCommand.java
@@ -18,7 +18,7 @@ public abstract class StudentCommand extends Command {
 
 
     /**
-     * Returns the (@code COMMAND_NAME) concatenated with the name of the input (@code subCommand).
+     * Returns the {@code COMMAND_NAME} concatenated with the name of the input {@code subCommand}.
      * @param subCommand
      * @return Qualified name
      */

--- a/src/main/java/seedu/planner/logic/commands/student/StudentGradeCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/student/StudentGradeCommand.java
@@ -3,6 +3,7 @@ package seedu.planner.logic.commands.student;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalDouble;
 
@@ -91,6 +92,22 @@ public class StudentGradeCommand extends StudentCommand {
 
         CumulativeGrade cumulativeGrade = activeStudent.getCumulativeGrade();
         return new CommandResult(generateSuccessMessage(activeStudent, cumulativeGrade));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash();
     }
 }
 //@@author

--- a/src/main/java/seedu/planner/logic/commands/student/StudentGradeCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/student/StudentGradeCommand.java
@@ -35,7 +35,7 @@ public class StudentGradeCommand extends StudentCommand {
 
     /**
      * Generates a command execution success message for listing the grades and statistics of the
-     * specified (@code activeStudent).
+     * specified {@code activeStudent}.
      */
     private String generateSuccessMessage(Student activeStudent, CumulativeGrade cumulativeGrade) {
         OptionalDouble gradeValue = cumulativeGrade.getAverage();

--- a/src/main/java/seedu/planner/logic/commands/student/StudentListCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/student/StudentListCommand.java
@@ -26,20 +26,20 @@ public class StudentListCommand extends StudentCommand {
      * Generates a command execution success message for listing the students in the planner.
      */
     private String generateSuccessMessage(ObservableList<Student> students) {
-        StringBuffer sb = new StringBuffer();
+        StringBuffer buffer = new StringBuffer();
         boolean isFirst = true;
         for (int i = 0; i < students.size(); ++i) {
             Student student = students.get(i);
             if (!isFirst) {
-                sb.append("\n");
+                buffer.append("\n");
             }
-            sb.append(i + 1);
-            sb.append(": ");
-            sb.append(student);
+            buffer.append(i + 1);
+            buffer.append(": ");
+            buffer.append(student);
             isFirst = false;
         }
 
-        return String.format(MESSAGE_SUCCESS, sb.length() == 0 ? "[None]" : sb.toString());
+        return String.format(MESSAGE_SUCCESS, buffer.length() == 0 ? "[None]" : buffer.toString());
     }
 
     /**

--- a/src/main/java/seedu/planner/logic/commands/student/StudentListCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/student/StudentListCommand.java
@@ -2,6 +2,8 @@ package seedu.planner.logic.commands.student;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Objects;
+
 import javafx.collections.ObservableList;
 import seedu.planner.logic.commands.CommandResult;
 import seedu.planner.logic.commands.exceptions.CommandException;
@@ -55,6 +57,22 @@ public class StudentListCommand extends StudentCommand {
         ObservableList<Student> lastShownList = model.getStudentList();
 
         return new CommandResult(generateSuccessMessage(lastShownList));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash();
     }
 }
 //@@author

--- a/src/main/java/seedu/planner/logic/commands/student/StudentRemoveCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/student/StudentRemoveCommand.java
@@ -3,6 +3,8 @@ package seedu.planner.logic.commands.student;
 import static java.util.Objects.requireNonNull;
 import static seedu.planner.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Objects;
+
 import javafx.collections.ObservableList;
 import seedu.planner.commons.core.Messages;
 import seedu.planner.commons.core.index.Index;
@@ -34,7 +36,7 @@ public class StudentRemoveCommand extends StudentCommand {
     }
 
     /**
-     * Generates a command execution success message for removing the (@removedStudent) from the list of students.
+     * Generates a command execution success message for removing the {@code removedStudent} from the list of students.
      */
     private String generateSuccessMessage(Student removedStudent) {
         return String.format(MESSAGE_REMOVE_STUDENT_SUCCESS, removedStudent);
@@ -52,13 +54,30 @@ public class StudentRemoveCommand extends StudentCommand {
         ObservableList<Student> lastShownList = model.getStudentList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
         }
 
         Student removedStudent = lastShownList.get(index.getZeroBased());
         model.removeStudent(removedStudent);
 
         return new CommandResult(generateSuccessMessage(removedStudent));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        StudentRemoveCommand that = (StudentRemoveCommand) o;
+        return index.equals(that.index);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(index);
     }
 }
 //@@author

--- a/src/main/java/seedu/planner/logic/commands/timetable/TimeTableActiveCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/timetable/TimeTableActiveCommand.java
@@ -5,6 +5,8 @@ import static seedu.planner.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.planner.logic.parser.CliSyntax.PREFIX_STUDENT_SEM;
 import static seedu.planner.logic.parser.CliSyntax.PREFIX_STUDENT_YEAR;
 
+import java.util.Objects;
+
 import seedu.planner.commons.core.Messages;
 import seedu.planner.logic.commands.CommandResult;
 import seedu.planner.logic.commands.exceptions.CommandException;
@@ -27,7 +29,6 @@ public class TimeTableActiveCommand extends TimeTableCommand {
         + "Example: " + getQualifiedCommand(COMMAND_WORD) + " year/1 sem/ONE";
 
     public static final String MESSAGE_ACTIVE_TIMETABLE_SUCCESS = "Set semester as active: %1$s";
-    public static final String MESSAGE_INVALID_SEMESTER = "Semester does not exist in list of timetables: %1$s";
 
     private final StudentSemester studentSemester;
 
@@ -37,7 +38,7 @@ public class TimeTableActiveCommand extends TimeTableCommand {
     }
 
     /**
-     * Generates a command execution success message for selecting the timetable with the given (@code semesterYear)
+     * Generates a command execution success message for selecting the timetable with the given {@code semesterYear}
      * for the currently selected student.
      */
     private String generateSuccessMessage(StudentSemester semesterYear) {
@@ -54,12 +55,29 @@ public class TimeTableActiveCommand extends TimeTableCommand {
         }
 
         if (!model.hasSemester(studentSemester)) {
-            throw new CommandException(String.format(MESSAGE_INVALID_SEMESTER, studentSemester));
+            throw new CommandException(String.format(Messages.MESSAGE_INVALID_SEMESTER, studentSemester));
         }
 
         model.activateSemester(studentSemester);
 
         return new CommandResult(generateSuccessMessage(studentSemester));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TimeTableActiveCommand that = (TimeTableActiveCommand) o;
+        return studentSemester.equals(that.studentSemester);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(studentSemester);
     }
 }
 //@@author

--- a/src/main/java/seedu/planner/logic/commands/timetable/TimeTableAddCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/timetable/TimeTableAddCommand.java
@@ -5,6 +5,8 @@ import static seedu.planner.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.planner.logic.parser.CliSyntax.PREFIX_STUDENT_SEM;
 import static seedu.planner.logic.parser.CliSyntax.PREFIX_STUDENT_YEAR;
 
+import java.util.Objects;
+
 import seedu.planner.commons.core.Messages;
 import seedu.planner.logic.commands.CommandResult;
 import seedu.planner.logic.commands.exceptions.CommandException;
@@ -38,7 +40,7 @@ public class TimeTableAddCommand extends TimeTableCommand {
 
     /**
      * Generates a command execution success message for adding an empty timetable
-     * with the given (@code semesterYear) to the currently selected student's list of timetables.
+     * with the given {@code semesterYear} to the currently selected student's list of timetables.
      */
     private String generateSuccessMessage(StudentSemester semesterYear) {
         return String.format(MESSAGE_ADD_TIMETABLE_SUCCESS, semesterYear);
@@ -60,6 +62,23 @@ public class TimeTableAddCommand extends TimeTableCommand {
         model.addSemesterTimeTable(studentSemester);
 
         return new CommandResult(generateSuccessMessage(studentSemester));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TimeTableAddCommand that = (TimeTableAddCommand) o;
+        return studentSemester.equals(that.studentSemester);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(studentSemester);
     }
 }
 //@@author

--- a/src/main/java/seedu/planner/logic/commands/timetable/TimeTableCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/timetable/TimeTableCommand.java
@@ -18,7 +18,7 @@ public abstract class TimeTableCommand extends Command {
 
 
     /**
-     * Returns the (@code COMMAND_NAME) concatenated with the name of the input (@code subCommand).
+     * Returns the {@code COMMAND_NAME} concatenated with the name of the input {@code subCommand}.
      * @param subCommand
      * @return Qualified name
      */

--- a/src/main/java/seedu/planner/logic/commands/timetable/TimeTableListCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/timetable/TimeTableListCommand.java
@@ -3,6 +3,7 @@ package seedu.planner.logic.commands.timetable;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Objects;
 
 import seedu.planner.commons.core.Messages;
 import seedu.planner.logic.commands.CommandResult;
@@ -43,6 +44,22 @@ public class TimeTableListCommand extends TimeTableCommand {
         }
 
         return new CommandResult(generateSuccessMessage(activeStudent, activeStudent.getStudentSemesters()));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash();
     }
 }
 //@@author

--- a/src/main/java/seedu/planner/logic/commands/timetable/TimeTableListCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/timetable/TimeTableListCommand.java
@@ -23,7 +23,7 @@ public class TimeTableListCommand extends TimeTableCommand {
         + ": List the timetables of the active student.\n"
         + "Example: " + getQualifiedCommand(COMMAND_WORD);
 
-    public static final String MESSAGE_SUCCESS = "Listed semesters for the active student (%1$s):\n%2$s";
+    public static final String MESSAGE_SUCCESS = "Listed semesters for the selected student (%1$s):\n%2$s";
 
     /**
      * Generates a command execution success message for listing the timetables of

--- a/src/main/java/seedu/planner/logic/commands/timetable/TimeTableRemoveCommand.java
+++ b/src/main/java/seedu/planner/logic/commands/timetable/TimeTableRemoveCommand.java
@@ -5,6 +5,8 @@ import static seedu.planner.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.planner.logic.parser.CliSyntax.PREFIX_STUDENT_SEM;
 import static seedu.planner.logic.parser.CliSyntax.PREFIX_STUDENT_YEAR;
 
+import java.util.Objects;
+
 import seedu.planner.commons.core.Messages;
 import seedu.planner.logic.commands.CommandResult;
 import seedu.planner.logic.commands.exceptions.CommandException;
@@ -27,7 +29,6 @@ public class TimeTableRemoveCommand extends TimeTableCommand {
         + "Example: " + getQualifiedCommand(COMMAND_WORD) + " year/1 sem/ONE";
 
     public static final String MESSAGE_REMOVE_TIMETABLE_SUCCESS = "Removed timetable from semester: %1$s";
-    public static final String MESSAGE_INVALID_SEMESTER = "Semester does not exist in list of timetables: %1$s";
 
     private final StudentSemester studentSemester;
 
@@ -38,7 +39,7 @@ public class TimeTableRemoveCommand extends TimeTableCommand {
 
     /**
      * Generates a command execution success message for removing the timetable
-     * with the given (@code semesterYear) from the currently selected student's list of timetables.
+     * with the given {@code semesterYear} from the currently selected student's list of timetables.
      */
     private String generateSuccessMessage(StudentSemester semesterYear) {
         return String.format(MESSAGE_REMOVE_TIMETABLE_SUCCESS, semesterYear);
@@ -54,12 +55,29 @@ public class TimeTableRemoveCommand extends TimeTableCommand {
         }
 
         if (!model.hasSemester(studentSemester)) {
-            throw new CommandException(String.format(MESSAGE_INVALID_SEMESTER, studentSemester));
+            throw new CommandException(String.format(Messages.MESSAGE_INVALID_SEMESTER, studentSemester));
         }
 
         model.removeSemesterTimeTable(studentSemester);
 
         return new CommandResult(generateSuccessMessage(studentSemester));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TimeTableRemoveCommand that = (TimeTableRemoveCommand) o;
+        return studentSemester.equals(that.studentSemester);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(studentSemester);
     }
 }
 //@@author

--- a/src/main/java/seedu/planner/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/planner/logic/parser/ParserUtil.java
@@ -48,7 +48,7 @@ public class ParserUtil {
             throw new ParseException(MESSAGE_INVALID_DEGREE_YEAR);
         } else {
             int yearInt = Integer.parseInt(trimmedYear);
-            if (yearInt < 0 || yearInt > 6) {
+            if (yearInt < DegreeYear.MIN_VALUE || yearInt > DegreeYear.MAX_VALUE) { // Year 1 to 6 inclusive
                 throw new ParseException(MESSAGE_INVALID_DEGREE_YEAR);
             }
         }

--- a/src/main/java/seedu/planner/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/planner/logic/parser/ParserUtil.java
@@ -146,6 +146,7 @@ public class ParserUtil {
             throw new ParseException("Lessons Should be a number");
         }
     }
+    //@@author
 
     //@@author thetruevincentchow
     /**

--- a/src/main/java/seedu/planner/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/planner/logic/parser/ParserUtil.java
@@ -20,8 +20,7 @@ import seedu.planner.model.time.Semester;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index must be a non-zero unsigned integer.";
-    public static final String MESSAGE_INVALID_DEGREE_YEAR =
-            "Year must be a non-negative unsigned integer, from 1 to 6, representing your current year of study.";
+    public static final String MESSAGE_INVALID_DEGREE_YEAR = DegreeYear.MESSAGE_CONSTRAINTS;
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be

--- a/src/main/java/seedu/planner/logic/parser/SubCommandSplitter.java
+++ b/src/main/java/seedu/planner/logic/parser/SubCommandSplitter.java
@@ -1,0 +1,45 @@
+package seedu.planner.logic.parser;
+
+import static seedu.planner.commons.core.Messages.MESSAGE_UNKNOWN_SUBCOMMAND;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import seedu.planner.logic.parser.exceptions.ParseException;
+
+//@@author thetruevincentchow
+public class SubCommandSplitter {
+    /**
+     * Used for initial separation of command word and args.
+     */
+    private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<subCommand>.*)",
+        Pattern.DOTALL);
+
+    private final String command;
+    private final String subcommand;
+
+    /**
+     * Splits user command input into a command and subcommand string.
+     * The subcommand can be empty or contain newlines and other whitespace.
+     * @param userInput user sub-command input string
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public SubCommandSplitter(String userInput, String failureMessage) throws ParseException {
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
+        if (!matcher.matches()) {
+            throw new ParseException(String.format(MESSAGE_UNKNOWN_SUBCOMMAND, failureMessage));
+        }
+
+        command = matcher.group("commandWord");
+        subcommand = matcher.group("subCommand");
+    }
+
+    public String getCommand() {
+        return command;
+    }
+
+    public String getSubCommand() {
+        return subcommand;
+    }
+}
+//@@author

--- a/src/main/java/seedu/planner/logic/parser/exemptions/ExemptCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/exemptions/ExemptCommandParser.java
@@ -13,7 +13,6 @@ import seedu.planner.logic.parser.Parser;
 import seedu.planner.logic.parser.exceptions.ParseException;
 
 //@@author thetruevincentchow
-
 /**
  * Parses sub-commands of the "exempt" command and creates a new ExemptCommand object
  */

--- a/src/main/java/seedu/planner/logic/parser/exemptions/ExemptCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/exemptions/ExemptCommandParser.java
@@ -2,14 +2,12 @@ package seedu.planner.logic.parser.exemptions;
 
 import static seedu.planner.commons.core.Messages.MESSAGE_UNKNOWN_SUBCOMMAND;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import seedu.planner.logic.commands.exemptions.ExemptAddCommand;
 import seedu.planner.logic.commands.exemptions.ExemptCommand;
 import seedu.planner.logic.commands.exemptions.ExemptListCommand;
 import seedu.planner.logic.commands.exemptions.ExemptRemoveCommand;
 import seedu.planner.logic.parser.Parser;
+import seedu.planner.logic.parser.SubCommandSplitter;
 import seedu.planner.logic.parser.exceptions.ParseException;
 
 //@@author thetruevincentchow
@@ -17,10 +15,6 @@ import seedu.planner.logic.parser.exceptions.ParseException;
  * Parses sub-commands of the "exempt" command and creates a new ExemptCommand object
  */
 public class ExemptCommandParser implements Parser<ExemptCommand> {
-    /**
-     * Used for initial separation of command word and args.
-     */
-    private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+) ?(?<arguments>.*)");
 
     /**
      * Parses user subcommand input into command for execution.
@@ -31,13 +25,10 @@ public class ExemptCommandParser implements Parser<ExemptCommand> {
      */
     @Override
     public ExemptCommand parse(String userInput) throws ParseException {
-        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
-        if (!matcher.matches()) {
-            throw new ParseException(String.format(MESSAGE_UNKNOWN_SUBCOMMAND, ExemptCommand.MESSAGE_USAGE));
-        }
+        SubCommandSplitter subCommandSplitter = new SubCommandSplitter(userInput, ExemptCommand.MESSAGE_USAGE);
 
-        final String commandWord = matcher.group("commandWord");
-        final String arguments = matcher.group("arguments");
+        final String commandWord = subCommandSplitter.getCommand();
+        final String arguments = subCommandSplitter.getSubCommand();
 
         switch (commandWord) {
         case ExemptAddCommand.COMMAND_WORD:

--- a/src/main/java/seedu/planner/logic/parser/module/ModuleCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/module/ModuleCommandParser.java
@@ -2,15 +2,13 @@ package seedu.planner.logic.parser.module;
 
 import static seedu.planner.commons.core.Messages.MESSAGE_UNKNOWN_SUBCOMMAND;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import seedu.planner.logic.commands.module.ModuleAddCommand;
 import seedu.planner.logic.commands.module.ModuleCommand;
 import seedu.planner.logic.commands.module.ModuleGradeCommand;
 import seedu.planner.logic.commands.module.ModuleListCommand;
 import seedu.planner.logic.commands.module.ModuleRemoveCommand;
 import seedu.planner.logic.parser.Parser;
+import seedu.planner.logic.parser.SubCommandSplitter;
 import seedu.planner.logic.parser.exceptions.ParseException;
 
 //@@author thetruevincentchow
@@ -18,11 +16,6 @@ import seedu.planner.logic.parser.exceptions.ParseException;
  * Parses sub-commands of the "module" command and creates a new ModuleCommand object
  */
 public class ModuleCommandParser implements Parser<ModuleCommand> {
-    /**
-     * Used for initial separation of command word and args.
-     */
-    private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+) ?(?<arguments>.*)");
-
     /**
      * Parses user subcommand input into command for execution.
      *
@@ -32,13 +25,10 @@ public class ModuleCommandParser implements Parser<ModuleCommand> {
      */
     @Override
     public ModuleCommand parse(String userInput) throws ParseException {
-        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
-        if (!matcher.matches()) {
-            throw new ParseException(String.format(MESSAGE_UNKNOWN_SUBCOMMAND, ModuleCommand.MESSAGE_USAGE));
-        }
+        SubCommandSplitter subCommandSplitter = new SubCommandSplitter(userInput, ModuleCommand.MESSAGE_USAGE);
 
-        final String commandWord = matcher.group("commandWord");
-        final String arguments = matcher.group("arguments");
+        final String commandWord = subCommandSplitter.getCommand();
+        final String arguments = subCommandSplitter.getSubCommand();
 
         switch (commandWord) {
         case ModuleAddCommand.COMMAND_WORD:

--- a/src/main/java/seedu/planner/logic/parser/module/ModuleGradeCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/module/ModuleGradeCommandParser.java
@@ -31,7 +31,7 @@ public class ModuleGradeCommandParser implements Parser<ModuleGradeCommand> {
     public ModuleGradeCommand parse(String args) throws ParseException {
         requireNonNull(args);
 
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_GRADE);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(" " + args, PREFIX_GRADE);
 
         if (argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModuleGradeCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/planner/logic/parser/student/StudentAddCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/student/StudentAddCommandParser.java
@@ -38,7 +38,6 @@ public class StudentAddCommandParser implements Parser<StudentAddCommand> {
 
         // NOTE: the concatenation " " is a workaround for `ArgumentTokenizer` treating the first argument as the
         // preamble
-        // TODO: use ArgumentTokenizer for all subcommands
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(" " + args, PREFIX_NAME, PREFIX_MAJOR);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_MAJOR)

--- a/src/main/java/seedu/planner/logic/parser/student/StudentCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/student/StudentCommandParser.java
@@ -2,9 +2,6 @@ package seedu.planner.logic.parser.student;
 
 import static seedu.planner.commons.core.Messages.MESSAGE_UNKNOWN_SUBCOMMAND;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import seedu.planner.logic.commands.student.StudentActiveCommand;
 import seedu.planner.logic.commands.student.StudentAddCommand;
 import seedu.planner.logic.commands.student.StudentCommand;
@@ -12,6 +9,7 @@ import seedu.planner.logic.commands.student.StudentGradeCommand;
 import seedu.planner.logic.commands.student.StudentListCommand;
 import seedu.planner.logic.commands.student.StudentRemoveCommand;
 import seedu.planner.logic.parser.Parser;
+import seedu.planner.logic.parser.SubCommandSplitter;
 import seedu.planner.logic.parser.exceptions.ParseException;
 
 //@@author thetruevincentchow
@@ -19,11 +17,6 @@ import seedu.planner.logic.parser.exceptions.ParseException;
  * Parses sub-commands of the "student" command and creates a new StudentCommand object
  */
 public class StudentCommandParser implements Parser<StudentCommand> {
-    /**
-     * Used for initial separation of command word and args.
-     */
-    private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+) ?(?<arguments>.*)");
-
     /**
      * Parses user subcommand input into command for execution.
      *
@@ -33,13 +26,10 @@ public class StudentCommandParser implements Parser<StudentCommand> {
      */
     @Override
     public StudentCommand parse(String userInput) throws ParseException {
-        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
-        if (!matcher.matches()) {
-            throw new ParseException(String.format(MESSAGE_UNKNOWN_SUBCOMMAND, StudentCommand.MESSAGE_USAGE));
-        }
+        SubCommandSplitter subCommandSplitter = new SubCommandSplitter(userInput, StudentCommand.MESSAGE_USAGE);
 
-        final String commandWord = matcher.group("commandWord");
-        final String arguments = matcher.group("arguments");
+        final String commandWord = subCommandSplitter.getCommand();
+        final String arguments = subCommandSplitter.getSubCommand();
 
         switch (commandWord) {
         case StudentRemoveCommand.COMMAND_WORD:

--- a/src/main/java/seedu/planner/logic/parser/timetable/TimeTableActiveCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/timetable/TimeTableActiveCommandParser.java
@@ -47,7 +47,7 @@ public class TimeTableActiveCommandParser implements Parser<TimeTableActiveComma
         final Semester sem = ParserUtil.parseSemester(argMultimap.getValue(PREFIX_STUDENT_SEM).get());
 
         SemesterYear semesterYear = new SemesterYear(sem, 0); // TODO: input academic year
-        StudentSemester studentSemester = new StudentSemester(semesterYear, year.getYear());
+        StudentSemester studentSemester = new StudentSemester(semesterYear, year);
         return new TimeTableActiveCommand(studentSemester);
     }
 }

--- a/src/main/java/seedu/planner/logic/parser/timetable/TimeTableAddCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/timetable/TimeTableAddCommandParser.java
@@ -43,7 +43,7 @@ public class TimeTableAddCommandParser implements Parser<TimeTableAddCommand> {
         final Semester sem = ParserUtil.parseSemester(argMultimap.getValue(PREFIX_STUDENT_SEM).get());
 
         SemesterYear semesterYear = new SemesterYear(sem, 0); // TODO: input academic year
-        StudentSemester studentSemester = new StudentSemester(semesterYear, year.getYear());
+        StudentSemester studentSemester = new StudentSemester(semesterYear, year);
         return new TimeTableAddCommand(studentSemester);
     }
 }

--- a/src/main/java/seedu/planner/logic/parser/timetable/TimeTableCommandParser.java
+++ b/src/main/java/seedu/planner/logic/parser/timetable/TimeTableCommandParser.java
@@ -2,15 +2,13 @@ package seedu.planner.logic.parser.timetable;
 
 import static seedu.planner.commons.core.Messages.MESSAGE_UNKNOWN_SUBCOMMAND;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import seedu.planner.logic.commands.timetable.TimeTableActiveCommand;
 import seedu.planner.logic.commands.timetable.TimeTableAddCommand;
 import seedu.planner.logic.commands.timetable.TimeTableCommand;
 import seedu.planner.logic.commands.timetable.TimeTableListCommand;
 import seedu.planner.logic.commands.timetable.TimeTableRemoveCommand;
 import seedu.planner.logic.parser.Parser;
+import seedu.planner.logic.parser.SubCommandSplitter;
 import seedu.planner.logic.parser.exceptions.ParseException;
 
 //@@author thetruevincentchow
@@ -20,11 +18,6 @@ import seedu.planner.logic.parser.exceptions.ParseException;
  */
 public class TimeTableCommandParser implements Parser<TimeTableCommand> {
     /**
-     * Used for initial separation of command word and args.
-     */
-    private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+) ?(?<arguments>.*)");
-
-    /**
      * Parses user subcommand input into command for execution.
      *
      * @param userInput user subcommand input string
@@ -33,13 +26,10 @@ public class TimeTableCommandParser implements Parser<TimeTableCommand> {
      */
     @Override
     public TimeTableCommand parse(String userInput) throws ParseException {
-        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
-        if (!matcher.matches()) {
-            throw new ParseException(String.format(MESSAGE_UNKNOWN_SUBCOMMAND, TimeTableCommand.MESSAGE_USAGE));
-        }
+        SubCommandSplitter subCommandSplitter = new SubCommandSplitter(userInput, TimeTableCommand.MESSAGE_USAGE);
 
-        final String commandWord = matcher.group("commandWord");
-        final String arguments = matcher.group("arguments");
+        final String commandWord = subCommandSplitter.getCommand();
+        final String arguments = subCommandSplitter.getSubCommand();
 
         switch (commandWord) {
         case TimeTableRemoveCommand.COMMAND_WORD:

--- a/src/main/java/seedu/planner/model/Model.java
+++ b/src/main/java/seedu/planner/model/Model.java
@@ -58,9 +58,13 @@ public interface Model {
 
     void activateStudent(Student student);
 
+    void activateValidStudent();
+
     void addStudent(Student student);
 
     void removeStudent(Student student);
+
+    List<StudentSemester> getStudentSemesters();
 
     ObservableList<ModuleCode> getEnrolledModuleCodes();
 

--- a/src/main/java/seedu/planner/model/ModelManager.java
+++ b/src/main/java/seedu/planner/model/ModelManager.java
@@ -173,6 +173,10 @@ public class ModelManager implements Model {
         planner.activateStudent(student);
     }
 
+    public void activateValidStudent() {
+        planner.activateValidStudent();
+    }
+
     public void addStudent(Student student) {
         requireAllNonNull(student);
         planner.addStudent(student);
@@ -181,6 +185,10 @@ public class ModelManager implements Model {
     public void removeStudent(Student student) {
         requireAllNonNull(student);
         planner.removeStudent(student);
+    }
+
+    public List<StudentSemester> getStudentSemesters() {
+        return planner.getActiveStudent().getStudentSemesters();
     }
 
     public ObservableList<ModuleCode> getEnrolledModuleCodes() {

--- a/src/main/java/seedu/planner/model/Planner.java
+++ b/src/main/java/seedu/planner/model/Planner.java
@@ -373,10 +373,6 @@ public class Planner implements ReadOnlyPlanner {
     public TimeTable getActiveTimeTable() {
         requireAllNonNull(getActiveStudent());
 
-        if (activeSemester == null && !getActiveStudent().getTimeTableMap().isEmpty()) {
-            activateValidSemester();
-        }
-
         return getActiveStudent().getTimeTable(activeSemester);
     }
 

--- a/src/main/java/seedu/planner/model/Planner.java
+++ b/src/main/java/seedu/planner/model/Planner.java
@@ -323,7 +323,7 @@ public class Planner implements ReadOnlyPlanner {
     }
 
     /**
-     * Replaces the currently active student with the student given by (@code editedStudent).
+     * Replaces the currently active student with the student given by {@code editedStudent}.
      *
      * @param student Student to copy for replacement.
      */
@@ -332,7 +332,19 @@ public class Planner implements ReadOnlyPlanner {
         students.setStudent(getActiveStudent(), student);
     }
 
+    /**
+     * Activates the given {@code student}. Any active semester will be deactivated.
+     * If {@code student} is {@code null}, then the active student (if any) will be deactivated.
+     * Only one {@link Student} may be active at a time.
+     * @param student Student to activate
+     */
     public void activateStudent(Student student) {
+        if (student == null) {
+            activeStudentIndex = -1;
+            activeSemester = null;
+            return;
+        }
+
         if (!students.contains(student)) {
             throw new StudentNotFoundException();
         }
@@ -381,12 +393,6 @@ public class Planner implements ReadOnlyPlanner {
             throw new TimeTableEmptyException();
         }
         activeSemester = getActiveStudent().getTimeTableMap().keySet().iterator().next();
-    }
-
-    public void removeTimeTable(StudentSemester keyToRemove) {
-        requireActiveStudentNonNull();
-        requireAllNonNull(keyToRemove);
-        getActiveStudent().removeTimeTable(keyToRemove);
     }
 
     public boolean hasSemester(StudentSemester semester) {

--- a/src/main/java/seedu/planner/model/grades/CumulativeGrade.java
+++ b/src/main/java/seedu/planner/model/grades/CumulativeGrade.java
@@ -6,7 +6,7 @@ import java.util.OptionalDouble;
 
 //@@author thetruevincentchow
 /**
- * Accumulates grade statistics of individual (@code Grade) and (@code credits).
+ * Accumulates grade statistics of individual {@link Grade} and {@code credits}.
  * Calculates Cumulative Average Point (CAP) and other statistics from inputs.
  */
 public class CumulativeGrade {
@@ -77,7 +77,7 @@ public class CumulativeGrade {
     /**
      * Returns Cumulative Average Point (CAP) of accumulated grades.
      * This excludes modules which are declared S/U.
-     * If there were no graded modules accumulated, then returns a (@code OptionalDouble.empty())
+     * If there were no graded modules accumulated, then returns a {@code OptionalDouble.empty()}
      * @return Cumulative Average Point
      */
     public OptionalDouble getAverage() {

--- a/src/main/java/seedu/planner/model/grades/Grade.java
+++ b/src/main/java/seedu/planner/model/grades/Grade.java
@@ -18,7 +18,7 @@ public class Grade {
 
     /**
      * The grade point of the letter grade. This ranges from 0.0 to 5.0.
-     * This does not account the S/U declaration (@code isSu).
+     * This does not account the S/U declaration {@code isSu}.
      *
      * @return Grade point of letter grade
      */

--- a/src/main/java/seedu/planner/model/grades/LetterGrade.java
+++ b/src/main/java/seedu/planner/model/grades/LetterGrade.java
@@ -31,6 +31,7 @@ public enum LetterGrade {
 
     public static final String MESSAGE_CONSTRAINTS =
         "Letter grades must be one of the following: " + getConcatenatedString();
+    private static final String INVALID_INPUT_NAME = "Invalid input name for LetterGrade: %1$s";
 
     public final OptionalDouble points;
     public final boolean isSu;
@@ -54,11 +55,11 @@ public enum LetterGrade {
     }
 
     /**
-     * Returns a (@code LetterGrade) given a user-friendly (@code letterGrade).
-     * Examples of (@code letterGrade) are "A+", "A-", "EXE".
+     * Returns a {@link LetterGrade} given a user-friendly {@code letterGrade} string.
+     * Examples of {@code letterGrade} are "A+", "A-", "EXE".
      * Usage of this method is preferred for handling user input.
      * @param letterGrade User-friendly letter grade
-     * @return LetterGrade object
+     * @return {@link LetterGrade} object
      */
     public static LetterGrade fromInputName(String letterGrade) {
         requireAllNonNull(letterGrade);
@@ -67,7 +68,7 @@ public enum LetterGrade {
                 return grade;
             }
         }
-        throw new IllegalArgumentException(String.format("Invalid input name for LetterGrade: %1$s", letterGrade));
+        throw new IllegalArgumentException(String.format(INVALID_INPUT_NAME, letterGrade));
     }
 
     @Override

--- a/src/main/java/seedu/planner/model/module/UniqueEnrollmentList.java
+++ b/src/main/java/seedu/planner/model/module/UniqueEnrollmentList.java
@@ -17,7 +17,7 @@ import seedu.planner.model.student.Enrollment;
 /**
  * A list of Enrollment that enforces uniqueness between its elements and does not allow nulls.
  * An enrollment is considered unique by comparing using {@code Enrollment#equals(Object)}.
- * As such, adding, updating and removal of enrollments uses (@code Enrollment#equals(Object)).
+ * As such, adding, updating and removal of enrollments uses {@code Enrollment#equals(Object)}.
  * <p>
  * Supports a minimal set of list operations.
  */

--- a/src/main/java/seedu/planner/model/module/UniqueModuleCodeList.java
+++ b/src/main/java/seedu/planner/model/module/UniqueModuleCodeList.java
@@ -14,7 +14,7 @@ import seedu.planner.model.module.exceptions.ModuleNotFoundException;
 /**
  * A list of ModuleCode that enforces uniqueness between its elements and does not allow nulls.
  * A module code is considered unique by comparing using {@code ModuleCode#equals(Object)}.
- * As such, adding, updating and removal of module codes uses (@code ModuleCode#equals(Object)).
+ * As such, adding, updating and removal of module codes uses {@code ModuleCode#equals(Object)}.
  * <p>
  * Supports a minimal set of list operations.
  */

--- a/src/main/java/seedu/planner/model/student/Major.java
+++ b/src/main/java/seedu/planner/model/student/Major.java
@@ -37,6 +37,7 @@ public class Major {
      */
     public Major(String major) {
         requireNonNull(major);
+        major = major.toUpperCase();
         checkArgument(isValidMajor(major), MESSAGE_CONSTRAINTS);
         if (major.toUpperCase().equals("CS")) {
             this.degreeProgramme = new ComputerScienceProgramme(null);

--- a/src/main/java/seedu/planner/model/student/Student.java
+++ b/src/main/java/seedu/planner/model/student/Student.java
@@ -22,11 +22,12 @@ import seedu.planner.model.module.Lesson;
 import seedu.planner.model.module.ModuleCode;
 import seedu.planner.model.module.UniqueModuleCodeList;
 import seedu.planner.model.programmes.specialisations.GenericSpecialisation;
+import seedu.planner.model.student.exceptions.SemesterKeyNotFoundException;
 import seedu.planner.model.time.StudentSemester;
 
 /**
- * Represents a Student in the planner book.
- * Guarantees: details are present and not null, field values are validated, immutable.
+ * Represents a Student in the planner.
+ * Guarantees: details are present and not null, field values are validated. Mutable.
  */
 public class Student {
 
@@ -100,7 +101,8 @@ public class Student {
         }
 
         /**
-         * NOTE: (@code specialisation) are not compared because (@ocde GenericSpecialisation#equal())
+         * NOTE: {@code specialisation} and {@code lessons} are not compared because
+         * {@code GenericSpecialisation#equal()} and {@code Lesson#equal()}
          * and its subclasses are not implemented.
          */
         Student otherStudent = (Student) other;
@@ -112,7 +114,8 @@ public class Student {
     @Override
     public int hashCode() {
         /**
-         * NOTE: (@code specialisation) are not hashed because (@ocde GenericSpecialisation#hashCode())
+         * NOTE: {@code specialisation} and {@code lessons} are not hashed because
+         * {@code GenericSpecialisation#hashCode()} and {@code Lesson#hashCode()}
          * and its subclasses are not implemented.
          */
         return Objects.hash(name, major, timeTableMap, exemptedModules);
@@ -140,18 +143,24 @@ public class Student {
 
     public void removeTimeTable(StudentSemester keyToRemove) {
         if (!timeTableMap.containsKey(keyToRemove)) {
-            throw new IllegalArgumentException("Semester does not exist in timetable list");
+            throw new SemesterKeyNotFoundException();
         }
         timeTableMap.remove(keyToRemove);
     }
 
+    /**
+     * Returns a sorted list of {@code StudentSemester} for the timetables of the student.
+     * {@link StudentSemester}s are sorted with the order given by {@link StudentSemester::compareTo}.
+     * @return Sorted list of semesters of timetables.
+     */
     public List<StudentSemester> getStudentSemesters() {
-        return new ArrayList<>(timeTableMap.keySet());
+        List<StudentSemester> studentSemesters = new ArrayList<>(timeTableMap.keySet());
+        studentSemesters.sort(StudentSemester::compareTo);
+        return studentSemesters;
     }
 
     /**
-     * Returns a list mof (@code ModuleCode) taken across all timetables.
-     *
+     * Returns a list of {@link ModuleCode} taken across all timetables.
      * @return List of all modules enrolled.
      */
     public ObservableList<ModuleCode> getAllEnrolledModules() {

--- a/src/main/java/seedu/planner/model/student/TimeTable.java
+++ b/src/main/java/seedu/planner/model/student/TimeTable.java
@@ -11,7 +11,7 @@ import seedu.planner.model.student.exceptions.EnrollmentNotFoundException;
 //@@author thetruevincentchow
 /**
  * Represents a timetable for a semester.
- * A (@code TimeTable) stores (@code Enrollment)s, where each enrollment must have a different module code.
+ * A {@code TimeTable} stores {@code Enrollment}s, where each enrollment must have a different module code.
  */
 public class TimeTable {
     private UniqueEnrollmentList enrollments = new UniqueEnrollmentList();

--- a/src/main/java/seedu/planner/model/time/DegreeYear.java
+++ b/src/main/java/seedu/planner/model/time/DegreeYear.java
@@ -5,8 +5,11 @@ import java.util.Objects;
 import seedu.planner.commons.core.index.Index;
 
 public class DegreeYear {
-    public static final String MESSAGE_CONSTRAINTS =
-        "Year must be a non-negative unsigned integer, from 1 to 6, representing your current year of study.";
+    public static final int MIN_VALUE = 1;
+    public static final int MAX_VALUE = 6;
+    public static final String MESSAGE_CONSTRAINTS = String.format(
+        "Year must be a non-negative unsigned integer, from %1$s to %2$s, representing your current year of study.",
+        MIN_VALUE, MAX_VALUE);
 
     private int year;
 
@@ -15,7 +18,7 @@ public class DegreeYear {
      * {@link Index#fromOneBased(int)}.
      */
     public DegreeYear(int year) {
-        if (year < 0) {
+        if (year < MIN_VALUE || year > MAX_VALUE) {
             throw new IndexOutOfBoundsException();
         }
 

--- a/src/main/java/seedu/planner/model/time/DegreeYear.java
+++ b/src/main/java/seedu/planner/model/time/DegreeYear.java
@@ -5,6 +5,9 @@ import java.util.Objects;
 import seedu.planner.commons.core.index.Index;
 
 public class DegreeYear {
+    public static final String MESSAGE_CONSTRAINTS =
+        "Year must be a non-negative unsigned integer, from 1 to 6, representing your current year of study.";
+
     private int year;
 
     /**

--- a/src/main/java/seedu/planner/model/time/SemesterYear.java
+++ b/src/main/java/seedu/planner/model/time/SemesterYear.java
@@ -2,9 +2,8 @@ package seedu.planner.model.time;
 
 import java.util.Objects;
 
-public class SemesterYear {
+public class SemesterYear implements Comparable<SemesterYear> {
     public static final String MESSAGE_CONSTRAINTS = "Semester year should be valid.";
-    // TODO: figure out required constraints
 
     protected final Semester sem;
     // TODO: support academic year in Student operations
@@ -12,6 +11,10 @@ public class SemesterYear {
     public SemesterYear(Semester sem, int academicYear) {
         this.sem = sem;
         // this.academicYear = academicYear;
+    }
+
+    public SemesterYear(Semester sem) {
+        this.sem = sem;
     }
 
     public Semester getSemester() {
@@ -48,5 +51,10 @@ public class SemesterYear {
     public String toString() {
         return String.format("%s", sem.getFullName());
         // return String.format("AY %d/%d %s", academicYear, academicYear+1, sem.toString());
+    }
+
+    @Override
+    public int compareTo(SemesterYear other) {
+        return sem.compareTo(other.sem);
     }
 }

--- a/src/main/java/seedu/planner/model/time/StudentSemester.java
+++ b/src/main/java/seedu/planner/model/time/StudentSemester.java
@@ -5,11 +5,15 @@ import java.util.Objects;
 
 public class StudentSemester implements Comparable<StudentSemester> {
     protected final SemesterYear semYear;
-    protected final int degreeYear;
+    protected final DegreeYear degreeYear;
 
-    public StudentSemester(SemesterYear semYear, int degreeYear) {
+    public StudentSemester(SemesterYear semYear, DegreeYear degreeYear) {
         this.semYear = semYear;
         this.degreeYear = degreeYear;
+    }
+
+    public StudentSemester(SemesterYear semYear, int degreeYear) {
+        this(semYear, new DegreeYear(degreeYear));
     }
 
     public SemesterYear getSemesterYear() {
@@ -17,7 +21,7 @@ public class StudentSemester implements Comparable<StudentSemester> {
     }
 
     public int getDegreeYear() {
-        return degreeYear;
+        return degreeYear.getYear();
     }
 
     @Override
@@ -31,13 +35,13 @@ public class StudentSemester implements Comparable<StudentSemester> {
             return false;
         } else {
             return semYear.equals(((StudentSemester) other).semYear)
-                && degreeYear == ((StudentSemester) other).degreeYear;
+                && degreeYear.equals(((StudentSemester) other).degreeYear);
         }
     }
 
     @Override
     public String toString() {
-        return String.format("Year %d, %s", degreeYear, semYear);
+        return String.format("Year %d, %s", degreeYear.getYear(), semYear);
     }
 
     @Override

--- a/src/main/java/seedu/planner/model/time/StudentSemester.java
+++ b/src/main/java/seedu/planner/model/time/StudentSemester.java
@@ -1,8 +1,9 @@
 package seedu.planner.model.time;
 
+import java.util.Comparator;
 import java.util.Objects;
 
-public class StudentSemester {
+public class StudentSemester implements Comparable<StudentSemester> {
     protected final SemesterYear semYear;
     protected final int degreeYear;
 
@@ -37,5 +38,12 @@ public class StudentSemester {
     @Override
     public String toString() {
         return String.format("Year %d, %s", degreeYear, semYear);
+    }
+
+    @Override
+    public int compareTo(StudentSemester other) {
+        return Comparator.comparing(StudentSemester::getDegreeYear)
+            .thenComparing(StudentSemester::getSemesterYear)
+            .compare(this, other);
     }
 }

--- a/src/main/java/seedu/planner/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/planner/model/util/SampleDataUtil.java
@@ -22,7 +22,7 @@ import seedu.planner.model.time.SemesterYear;
 import seedu.planner.model.time.StudentSemester;
 
 /**
- * Contains utility methods for populating {@code Planner} with sample data.
+ * Contains utility methods for populating {@link Planner} with sample data.
  */
 public class SampleDataUtil {
     public static Module[] getSampleModules() {
@@ -36,7 +36,7 @@ public class SampleDataUtil {
         Planner samplePlanner = new Planner();
         Student student = SampleDataUtil.getSampleStudent();
         samplePlanner.addStudent(student);
-        samplePlanner.activateStudent(student); // TODO: allow serialization of planner with no active student
+        samplePlanner.activateStudent(student);
         return samplePlanner;
     }
 
@@ -59,9 +59,8 @@ public class SampleDataUtil {
     }
 
     /**
-     * Returns a non-empty (@code TimeTableMap) which (@code Student) can immediately use.
-     *
-     * @return Non-empty (@code TimeTableMap)
+     * Returns a non-empty {@link TimeTable}.
+     * @return Non-empty {@link TimeTable}.
      */
     public static TimeTable getSampleTimeTable() {
         TimeTable timeTable = new TimeTable();

--- a/src/main/java/seedu/planner/storage/JsonAdaptedStudentSemester.java
+++ b/src/main/java/seedu/planner/storage/JsonAdaptedStudentSemester.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.planner.commons.exceptions.IllegalValueException;
+import seedu.planner.model.time.DegreeYear;
 import seedu.planner.model.time.SemesterYear;
 import seedu.planner.model.time.StudentSemester;
 
@@ -43,14 +44,12 @@ public class JsonAdaptedStudentSemester {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                 SemesterYear.class.getSimpleName()));
         }
-        // TODO: validate input
         /*if (!SemesterYear.isValidSemesterYear(semYear)) {
             throw new IllegalValueException(SemesterYear.MESSAGE_CONSTRAINTS);
         }*/
         final SemesterYear modelSemYear = semYear.toModelType();
 
-        // TODO: validate degreeYear
-        final int modelDegreeYear = degreeYear;
+        final DegreeYear modelDegreeYear = new DegreeYear(degreeYear);
         return new StudentSemester(modelSemYear, modelDegreeYear);
     }
 }

--- a/src/main/java/seedu/planner/storage/JsonAdaptedStudentSemester.java
+++ b/src/main/java/seedu/planner/storage/JsonAdaptedStudentSemester.java
@@ -49,7 +49,11 @@ public class JsonAdaptedStudentSemester {
         }*/
         final SemesterYear modelSemYear = semYear.toModelType();
 
-        final DegreeYear modelDegreeYear = new DegreeYear(degreeYear);
-        return new StudentSemester(modelSemYear, modelDegreeYear);
+        try {
+            final DegreeYear modelDegreeYear = new DegreeYear(degreeYear);
+            return new StudentSemester(modelSemYear, modelDegreeYear);
+        } catch (IndexOutOfBoundsException e) {
+            throw new IllegalValueException(DegreeYear.MESSAGE_CONSTRAINTS);
+        }
     }
 }

--- a/src/test/java/seedu/planner/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/planner/logic/commands/CommandTestUtil.java
@@ -3,6 +3,7 @@ package seedu.planner.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.planner.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.planner.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.planner.logic.parser.CliSyntax.PREFIX_MAJOR;
 import static seedu.planner.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.planner.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.planner.logic.parser.CliSyntax.PREFIX_STUDENT_SEM;
@@ -18,27 +19,42 @@ import seedu.planner.model.Model;
  */
 public class CommandTestUtil {
 
+    public static final String VALID_NAME_ALICE = "Alice";
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_DEGREE_YEAR = PREFIX_STUDENT_YEAR + "1";
     public static final String VALID_SEMESTER = PREFIX_STUDENT_SEM + "SPECIAL_ONE";
+    public static final String VALID_MAJOR_CS = "CS";
+    public static final String VALID_MAJOR_CS_LOWER = "cs";
+    public static final String VALID_MAJOR_IS = "IS";
 
     public static final String TIMETABLE_DESC = " " + VALID_DEGREE_YEAR + " " + VALID_SEMESTER;
+    public static final String NAME_DESC_ALICE = " " + PREFIX_NAME + VALID_NAME_ALICE;
+    public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
+    public static final String MAJOR_DESC_CS = " " + PREFIX_MAJOR + VALID_MAJOR_CS;
+    public static final String MAJOR_DESC_CS_LOWER = " " + PREFIX_MAJOR + VALID_MAJOR_CS_LOWER;
+    public static final String MAJOR_DESC_IS = " " + PREFIX_MAJOR + VALID_MAJOR_IS;
+    public static final String SEM_DESC = " " + VALID_SEMESTER;
+    public static final String DEGREE_YEAR_DESC = " " + VALID_DEGREE_YEAR;
 
     public static final String INVALID_DEGREE_YEAR = PREFIX_STUDENT_YEAR + "7"; // degree years are from 0 to 6
-    public static final String INVALID_SEMESTER = PREFIX_STUDENT_SEM + "asdf";
+    public static final String INVALID_SEM = PREFIX_STUDENT_SEM + "asdf";
+    public static final String INVALID_MAJOR = PREFIX_MAJOR + "as df";
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
-    public static final String INVALID_TIMETABLE_SEM_DESC = " " + VALID_DEGREE_YEAR + " " + INVALID_SEMESTER;
-    public static final String INVALID_TIMETABLE_YEAR_DESC = " " + INVALID_DEGREE_YEAR + " " + INVALID_SEMESTER;
-    public static final String INVALID_TIMETABLE_EMPTY_DESC = " " + VALID_DEGREE_YEAR + " " + PREFIX_STUDENT_SEM;
+    public static final String INVALID_MAJOR_DESC = " " + PREFIX_MAJOR + "CS*"; // '*' not allowed in majors
+    public static final String INVALID_TIMETABLE_SEM_DESC = " " + VALID_DEGREE_YEAR + " " + INVALID_SEM;
+    public static final String INVALID_TIMETABLE_YEAR_DESC = " " + INVALID_DEGREE_YEAR + " " + INVALID_SEM;
+    public static final String INVALID_TIMETABLE_EMPTY_DESC = " " + PREFIX_STUDENT_SEM + " " + PREFIX_STUDENT_SEM;
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
+
+    public static final String INVALID_SUBCOMMAND = "xyfaskdfasdf";
 
     /**
      * Executes the given {@code command}, confirms that <br>

--- a/src/test/java/seedu/planner/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/planner/logic/commands/CommandTestUtil.java
@@ -5,6 +5,8 @@ import static seedu.planner.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.planner.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.planner.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.planner.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.planner.logic.parser.CliSyntax.PREFIX_STUDENT_SEM;
+import static seedu.planner.logic.parser.CliSyntax.PREFIX_STUDENT_YEAR;
 import static seedu.planner.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.planner.testutil.Assert.assertThrows;
 
@@ -18,31 +20,22 @@ public class CommandTestUtil {
 
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
-    public static final String VALID_PHONE_AMY = "11111111";
-    public static final String VALID_PHONE_BOB = "22222222";
-    public static final String VALID_EMAIL_AMY = "amy@example.com";
-    public static final String VALID_EMAIL_BOB = "bob@example.com";
-    public static final String VALID_ADDRESS_AMY = "Block 312, Amy Street 1";
-    public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
-    public static final String VALID_TAG_HUSBAND = "husband";
-    public static final String VALID_TAG_FRIEND = "friend";
+    public static final String VALID_DEGREE_YEAR = PREFIX_STUDENT_YEAR + "1";
+    public static final String VALID_SEMESTER = PREFIX_STUDENT_SEM + "SPECIAL_ONE";
 
-    public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
-    public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
-    public static final String PHONE_DESC_AMY = " " + PREFIX_PHONE + VALID_PHONE_AMY;
-    public static final String PHONE_DESC_BOB = " " + PREFIX_PHONE + VALID_PHONE_BOB;
-    public static final String EMAIL_DESC_AMY = " " + PREFIX_EMAIL + VALID_EMAIL_AMY;
-    public static final String EMAIL_DESC_BOB = " " + PREFIX_EMAIL + VALID_EMAIL_BOB;
-    public static final String ADDRESS_DESC_AMY = " " + PREFIX_ADDRESS + VALID_ADDRESS_AMY;
-    public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
-    public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
-    public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
+    public static final String TIMETABLE_DESC = " " + VALID_DEGREE_YEAR + " " + VALID_SEMESTER;
+
+    public static final String INVALID_DEGREE_YEAR = PREFIX_STUDENT_YEAR + "7"; // degree years are from 0 to 6
+    public static final String INVALID_SEMESTER = PREFIX_STUDENT_SEM + "asdf";
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
+    public static final String INVALID_TIMETABLE_SEM_DESC = " " + VALID_DEGREE_YEAR + " " + INVALID_SEMESTER;
+    public static final String INVALID_TIMETABLE_YEAR_DESC = " " + INVALID_DEGREE_YEAR + " " + INVALID_SEMESTER;
+    public static final String INVALID_TIMETABLE_EMPTY_DESC = " " + VALID_DEGREE_YEAR + " " + PREFIX_STUDENT_SEM;
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
@@ -71,6 +64,21 @@ public class CommandTestUtil {
                                             Model expectedModel) {
         CommandResult expectedCommandResult = new CommandResult(expectedMessage);
         assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
+    }
+
+    /**
+     * Executes the given {@code command}, confirms that <br>
+     * - the execution of {@code command} is successful
+     * - the {@code actualModel} matches {@code expectedModel}
+     */
+    public static CommandResult assertCommandSuccess(Command command, Model actualModel, Model expectedModel) {
+        try {
+            CommandResult result = command.execute(actualModel);
+            assertEquals(expectedModel, actualModel);
+            return result;
+        } catch (CommandException ce) {
+            throw new AssertionError("Execution of command should not fail.", ce);
+        }
     }
 
     /**

--- a/src/test/java/seedu/planner/logic/commands/student/StudentActiveCommandTest.java
+++ b/src/test/java/seedu/planner/logic/commands/student/StudentActiveCommandTest.java
@@ -1,0 +1,72 @@
+package seedu.planner.logic.commands.student;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.planner.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.planner.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.planner.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
+import static seedu.planner.testutil.TypicalIndexes.INDEX_SECOND_STUDENT;
+import static seedu.planner.testutil.TypicalStudents.getTypicalPlanner;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.planner.commons.core.Messages;
+import seedu.planner.commons.core.index.Index;
+import seedu.planner.model.Model;
+import seedu.planner.model.ModelManager;
+import seedu.planner.model.UserPrefs;
+import seedu.planner.model.student.Student;
+
+
+//@@author thetruevincentchow
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code StudentActiveCommand}.
+ */
+public class StudentActiveCommandTest {
+    private Model model = new ModelManager(getTypicalPlanner(), new UserPrefs());
+
+    @Test
+    public void execute_validIndex_success() {
+        Student studentToActive = model.getStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
+        StudentActiveCommand studentActiveCommand = new StudentActiveCommand(INDEX_FIRST_STUDENT);
+
+        String expectedMessage = String.format(StudentActiveCommand.MESSAGE_ACTIVE_STUDENT_SUCCESS, studentToActive);
+
+        ModelManager expectedModel = new ModelManager(model.getPlanner(), new UserPrefs());
+        expectedModel.activateStudent(studentToActive);
+
+        assertCommandSuccess(studentActiveCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndex_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getStudentList().size() + 1);
+        StudentActiveCommand studentActiveCommand = new StudentActiveCommand(outOfBoundIndex);
+
+        assertCommandFailure(studentActiveCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        StudentActiveCommand activeFirstCommand = new StudentActiveCommand(INDEX_FIRST_STUDENT);
+        StudentActiveCommand activeSecondCommand = new StudentActiveCommand(INDEX_SECOND_STUDENT);
+
+        // same object -> returns true
+        assertTrue(activeFirstCommand.equals(activeFirstCommand));
+
+        // same values -> returns true
+        StudentActiveCommand activeFirstCommandCopy = new StudentActiveCommand(INDEX_FIRST_STUDENT);
+        assertTrue(activeFirstCommand.equals(activeFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(activeFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(activeFirstCommand.equals(null));
+
+        // different student -> returns false
+        assertFalse(activeFirstCommand.equals(activeSecondCommand));
+    }
+}
+//@@author

--- a/src/test/java/seedu/planner/logic/commands/student/StudentAddCommandTest.java
+++ b/src/test/java/seedu/planner/logic/commands/student/StudentAddCommandTest.java
@@ -1,0 +1,131 @@
+package seedu.planner.logic.commands.student;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.planner.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.planner.logic.commands.CommandResult;
+import seedu.planner.logic.commands.exceptions.CommandException;
+import seedu.planner.model.ModelStub;
+import seedu.planner.model.Planner;
+import seedu.planner.model.ReadOnlyPlanner;
+import seedu.planner.model.student.Student;
+import seedu.planner.testutil.StudentBuilder;
+
+//@@author thetruevincentchow
+/**
+ * Contains unit tests for {@code StudentAddCommand}.
+ */
+class StudentAddCommandTest {
+    @Test
+    public void constructor_nullStudent_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new StudentAddCommand(null));
+    }
+
+    @Test
+    public void execute_studentAcceptedByModel_addSuccessful() throws Exception {
+        ModelStubAcceptingStudentAdded modelStub = new ModelStubAcceptingStudentAdded();
+        Student validStudent = new StudentBuilder().build();
+
+        CommandResult commandResult = new StudentAddCommand(validStudent).execute(modelStub);
+
+        assertEquals(String.format(StudentAddCommand.MESSAGE_ADD_STUDENT_SUCCESS, validStudent),
+            commandResult.getFeedbackToUser());
+        assertEquals(Arrays.asList(validStudent), modelStub.studentsAdded);
+    }
+
+    @Test
+    public void execute_duplicateStudent_throwsCommandException() {
+        Student validStudent = new StudentBuilder().build();
+        StudentAddCommand studentAddCommand = new StudentAddCommand(validStudent);
+        ModelStub modelStub = new ModelStubWithStudent(validStudent);
+
+        assertThrows(CommandException.class, () -> studentAddCommand.execute(modelStub),
+            StudentAddCommand.MESSAGE_DUPLICATE_STUDENT);
+    }
+
+    @Test
+    public void equals() {
+        Student aliceCs = new StudentBuilder().withName("Alice").withMajor("CS").build();
+        Student bobCs = new StudentBuilder().withName("Bob").withMajor("CS").build();
+        Student aliceIs = new StudentBuilder().withName("Alice").withMajor("IS").build();
+        Student bobIs = new StudentBuilder().withName("Bob").withMajor("IS").build();
+
+        StudentAddCommand studentAddAliceCsCommand = new StudentAddCommand(aliceCs);
+        StudentAddCommand studentAddBobCsCommand = new StudentAddCommand(bobCs);
+        StudentAddCommand studentAddAliceIsCommand = new StudentAddCommand(aliceIs);
+        StudentAddCommand studentAddBobIsCommand = new StudentAddCommand(bobIs);
+
+        // same object -> returns true
+        assertTrue(studentAddAliceCsCommand.equals(studentAddAliceCsCommand));
+
+        // same values -> returns true
+        StudentAddCommand studentAddAliceCsCommandCopy = new StudentAddCommand(aliceCs);
+        assertTrue(studentAddAliceCsCommand.equals(studentAddAliceCsCommandCopy));
+
+        // different types -> returns false
+        assertFalse(studentAddAliceCsCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(studentAddAliceCsCommand.equals(null));
+
+        // different names -> returns false
+        assertFalse(studentAddAliceCsCommand.equals(studentAddBobCsCommand));
+
+        // different majors -> return false
+        assertFalse(studentAddAliceCsCommand.equals(studentAddAliceIsCommand));
+
+        // different names and majors -> return false
+        assertFalse(studentAddAliceCsCommand.equals(studentAddBobIsCommand));
+    }
+
+    /**
+     * A Model stub that always accept the student being added.
+     */
+    private class ModelStubAcceptingStudentAdded extends ModelStub {
+        final ArrayList<Student> studentsAdded = new ArrayList<>();
+
+        @Override
+        public boolean hasStudent(Student student) {
+            requireAllNonNull(student);
+            return studentsAdded.stream().anyMatch(student::isSameStudent);
+        }
+
+        @Override
+        public void addStudent(Student student) {
+            requireAllNonNull(student);
+            studentsAdded.add(student);
+        }
+
+        @Override
+        public ReadOnlyPlanner getPlanner() {
+            return new Planner();
+        }
+    }
+
+    /**
+     * A Model stub that contains a single student.
+     */
+    private class ModelStubWithStudent extends ModelStub {
+        private final Student student;
+
+        ModelStubWithStudent(Student student) {
+            requireAllNonNull(student);
+            this.student = student;
+        }
+
+        @Override
+        public boolean hasStudent(Student student) {
+            requireAllNonNull(student);
+            return this.student.isSameStudent(student);
+        }
+    }
+}
+//@@author

--- a/src/test/java/seedu/planner/logic/commands/student/StudentListCommandTest.java
+++ b/src/test/java/seedu/planner/logic/commands/student/StudentListCommandTest.java
@@ -1,0 +1,48 @@
+package seedu.planner.logic.commands.student;
+
+import static seedu.planner.logic.commands.CommandTestUtil.assertCommandSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.planner.model.Model;
+import seedu.planner.model.ModelManager;
+import seedu.planner.model.Planner;
+import seedu.planner.model.UserPrefs;
+import seedu.planner.testutil.TypicalStudents;
+
+//@@author thetruevincentchow
+/**
+ * Contains integration tests (interaction with the Model) for StudentListCommand.
+ */
+public class StudentListCommandTest {
+
+    private static final String nonEmptyExpectedFeedback = "Listed students in student list:\n"
+        + "1: n/Alice major/CS\n"
+        + "2: n/Bob major/CS";
+
+    private static final String emptyExpectedFeedback = "Listed students in student list:\n"
+        + "[None]";
+
+    @Test
+    public void execute_showNonEmptyStudentList() {
+        // NOTE: Construct new Planner here instead of using TypicalStudents.getTypicalPlanner()
+        //       for stability to changes in other code.
+        Planner planner = new Planner();
+        planner.addStudent(TypicalStudents.ALICE);
+        planner.addStudent(TypicalStudents.BOB);
+
+        Model model = new ModelManager(planner, new UserPrefs());
+        Model expectedModel = new ModelManager(model.getPlanner(), new UserPrefs());
+
+        assertCommandSuccess(new StudentListCommand(), model, nonEmptyExpectedFeedback, expectedModel);
+    }
+
+    @Test
+    public void execute_showEmptyStudentList() {
+        Model model = new ModelManager(new Planner(), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getPlanner(), new UserPrefs());
+
+        assertCommandSuccess(new StudentListCommand(), model, emptyExpectedFeedback, expectedModel);
+    }
+}
+//@@author

--- a/src/test/java/seedu/planner/logic/commands/student/StudentRemoveCommandTest.java
+++ b/src/test/java/seedu/planner/logic/commands/student/StudentRemoveCommandTest.java
@@ -1,0 +1,73 @@
+package seedu.planner.logic.commands.student;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.planner.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.planner.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.planner.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
+import static seedu.planner.testutil.TypicalIndexes.INDEX_SECOND_STUDENT;
+import static seedu.planner.testutil.TypicalStudents.getTypicalPlanner;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.planner.commons.core.Messages;
+import seedu.planner.commons.core.index.Index;
+import seedu.planner.model.Model;
+import seedu.planner.model.ModelManager;
+import seedu.planner.model.UserPrefs;
+import seedu.planner.model.student.Student;
+
+
+//@@author thetruevincentchow
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code StudentRemoveCommand}.
+ */
+public class StudentRemoveCommandTest {
+
+    private Model model = new ModelManager(getTypicalPlanner(), new UserPrefs());
+
+    @Test
+    public void execute_validIndex_success() {
+        Student studentToRemove = model.getStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
+        StudentRemoveCommand studentRemoveCommand = new StudentRemoveCommand(INDEX_FIRST_STUDENT);
+
+        String expectedMessage = String.format(StudentRemoveCommand.MESSAGE_REMOVE_STUDENT_SUCCESS, studentToRemove);
+
+        ModelManager expectedModel = new ModelManager(model.getPlanner(), new UserPrefs());
+        expectedModel.removeStudent(studentToRemove);
+
+        assertCommandSuccess(studentRemoveCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndex_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getStudentList().size() + 1);
+        StudentRemoveCommand studentRemoveCommand = new StudentRemoveCommand(outOfBoundIndex);
+
+        assertCommandFailure(studentRemoveCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        StudentRemoveCommand removeFirstCommand = new StudentRemoveCommand(INDEX_FIRST_STUDENT);
+        StudentRemoveCommand removeSecondCommand = new StudentRemoveCommand(INDEX_SECOND_STUDENT);
+
+        // same object -> returns true
+        assertTrue(removeFirstCommand.equals(removeFirstCommand));
+
+        // same values -> returns true
+        StudentRemoveCommand removeFirstCommandCopy = new StudentRemoveCommand(INDEX_FIRST_STUDENT);
+        assertTrue(removeFirstCommand.equals(removeFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(removeFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(removeFirstCommand.equals(null));
+
+        // different student -> returns false
+        assertFalse(removeFirstCommand.equals(removeSecondCommand));
+    }
+}
+//@@author

--- a/src/test/java/seedu/planner/logic/commands/timetable/TimeTableActiveCommandTest.java
+++ b/src/test/java/seedu/planner/logic/commands/timetable/TimeTableActiveCommandTest.java
@@ -1,0 +1,115 @@
+package seedu.planner.logic.commands.timetable;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.planner.commons.core.Messages.MESSAGE_INVALID_SEMESTER;
+import static seedu.planner.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.planner.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.planner.testutil.TypicalStudentSemesters.YEAR_1_SEM_ONE;
+import static seedu.planner.testutil.TypicalStudentSemesters.YEAR_1_SEM_TWO;
+import static seedu.planner.testutil.TypicalStudentSemesters.YEAR_2_SEM_ONE;
+import static seedu.planner.testutil.TypicalStudentSemesters.YEAR_6_SEM_ONE;
+import static seedu.planner.testutil.TypicalStudents.getTypicalPlannerWithTimeTables;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.planner.commons.core.Messages;
+import seedu.planner.logic.commands.exceptions.CommandException;
+import seedu.planner.model.Model;
+import seedu.planner.model.ModelManager;
+import seedu.planner.model.UserPrefs;
+import seedu.planner.model.student.Student;
+import seedu.planner.model.time.StudentSemester;
+import seedu.planner.testutil.TypicalStudents;
+
+//@@author thetruevincentchow
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code TimeTableActiveCommand}.
+ */
+public class TimeTableActiveCommandTest {
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalPlannerWithTimeTables(), new UserPrefs());
+        expectedModel = new ModelManager(getTypicalPlannerWithTimeTables(), new UserPrefs());
+
+        // failure of this precondition does not indicate test failure
+        assert !model.getStudentList().isEmpty();
+        assert !expectedModel.getStudentList().isEmpty();
+
+        Student validStudent = model.getStudentList().get(0);
+
+        model.activateStudent(validStudent);
+        expectedModel.activateStudent(validStudent);
+
+        // failure of this precondition does not indicate test failure
+        assert !model.getStudentSemesters().isEmpty();
+        assert !expectedModel.getStudentSemesters().isEmpty();
+    }
+
+    @Test
+    public void execute_validStudentSemester_success() {
+        StudentSemester studentSemesterToActive = model.getStudentSemesters().get(0);
+        TimeTableActiveCommand timeTableActiveCommand = new TimeTableActiveCommand(studentSemesterToActive);
+
+        String expectedMessage = String.format(TimeTableActiveCommand.MESSAGE_ACTIVE_TIMETABLE_SUCCESS,
+            studentSemesterToActive);
+
+        expectedModel.activateSemester(studentSemesterToActive);
+        assertCommandSuccess(timeTableActiveCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_noActiveStudent_throwsCommandException() {
+        Model model = new ModelManager(TypicalStudents.getTypicalPlanner(), new UserPrefs());
+        model.activateStudent(null);
+        TimeTableActiveCommand timeTableActiveCommand = new TimeTableActiveCommand(YEAR_1_SEM_ONE);
+
+        assertThrows(CommandException.class, () -> timeTableActiveCommand.execute(model),
+            Messages.MESSAGE_NO_STUDENT_ACTIVE);
+    }
+
+    @Test
+    public void execute_invalidStudentSemester_throwsCommandException() {
+        StudentSemester outOfBoundStudentSemester = YEAR_6_SEM_ONE;
+
+        // failure of this precondition does not indicate test failure
+        assert !model.getStudentSemesters().contains(outOfBoundStudentSemester);
+
+        TimeTableActiveCommand timeTableActiveCommand = new TimeTableActiveCommand(outOfBoundStudentSemester);
+        assertCommandFailure(timeTableActiveCommand, model, String.format(MESSAGE_INVALID_SEMESTER,
+            outOfBoundStudentSemester));
+    }
+
+    @Test
+    public void equals() {
+        TimeTableActiveCommand timeTableActiveYear1SemOne = new TimeTableActiveCommand(YEAR_1_SEM_ONE);
+        TimeTableActiveCommand timeTableActiveYear1SemTwo = new TimeTableActiveCommand(YEAR_1_SEM_TWO);
+        TimeTableActiveCommand timeTableActiveYear2SemOne = new TimeTableActiveCommand(YEAR_2_SEM_ONE);
+
+        // same object -> returns true
+        assertTrue(timeTableActiveYear1SemOne.equals(timeTableActiveYear1SemOne));
+
+        // same values -> returns true
+        TimeTableActiveCommand timeTableActiveYear1SemOneCopy = new TimeTableActiveCommand(YEAR_1_SEM_ONE);
+        assertTrue(timeTableActiveYear1SemOne.equals(timeTableActiveYear1SemOneCopy));
+
+        // different types -> returns false
+        assertFalse(timeTableActiveYear1SemOne.equals(1));
+
+        // null -> returns false
+        assertFalse(timeTableActiveYear1SemOne.equals(null));
+
+        // different StudentSemester -> returns false
+        assertFalse(timeTableActiveYear1SemOne.equals(timeTableActiveYear1SemTwo));
+        assertFalse(timeTableActiveYear1SemOne.equals(timeTableActiveYear2SemOne));
+        assertFalse(timeTableActiveYear1SemTwo.equals(timeTableActiveYear2SemOne));
+    }
+}
+//@@author
+

--- a/src/test/java/seedu/planner/logic/commands/timetable/TimeTableAddCommandTest.java
+++ b/src/test/java/seedu/planner/logic/commands/timetable/TimeTableAddCommandTest.java
@@ -1,0 +1,154 @@
+package seedu.planner.logic.commands.timetable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.planner.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.planner.testutil.TypicalStudentSemesters.YEAR_1_SEM_ONE;
+import static seedu.planner.testutil.TypicalStudentSemesters.YEAR_1_SEM_TWO;
+import static seedu.planner.testutil.TypicalStudentSemesters.YEAR_2_SEM_ONE;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.planner.commons.core.Messages;
+import seedu.planner.logic.commands.CommandResult;
+import seedu.planner.logic.commands.exceptions.CommandException;
+import seedu.planner.model.ModelStub;
+import seedu.planner.model.Planner;
+import seedu.planner.model.ReadOnlyPlanner;
+import seedu.planner.model.time.StudentSemester;
+
+//@@author thetruevincentchow
+/**
+ * Contains unit tests for {@code TimeTableAddCommand}.
+ */
+class TimeTableAddCommandTest {
+
+    private static final StudentSemester validStudentSemester = YEAR_1_SEM_ONE;
+
+    @Test
+    public void constructor_nullStudentSemester_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new TimeTableAddCommand(null));
+    }
+
+    @Test
+    public void execute_noActiveStudent_throwsCommandException() {
+        ModelStubNoActiveStudent modelStub = new ModelStubNoActiveStudent();
+        TimeTableAddCommand timeTableAddCommand = new TimeTableAddCommand(validStudentSemester);
+
+        assertThrows(CommandException.class, () -> timeTableAddCommand.execute(modelStub),
+            Messages.MESSAGE_NO_STUDENT_ACTIVE);
+    }
+
+    @Test
+    public void execute_studentSemesterAcceptedByModel_addSuccessful() throws Exception {
+        ModelStubAcceptingTimeTableAdded modelStub = new ModelStubAcceptingTimeTableAdded();
+
+        CommandResult commandResult = new TimeTableAddCommand(validStudentSemester).execute(modelStub);
+
+        assertEquals(String.format(TimeTableAddCommand.MESSAGE_ADD_TIMETABLE_SUCCESS, validStudentSemester),
+            commandResult.getFeedbackToUser());
+        assertEquals(Arrays.asList(validStudentSemester), modelStub.studentSemestersAdded);
+    }
+
+    @Test
+    public void execute_duplicateStudentSemester_throwsCommandException() {
+        TimeTableAddCommand timeTableAddCommand = new TimeTableAddCommand(validStudentSemester);
+        ModelStub modelStub = new ModelStubWithTimeTable(validStudentSemester);
+
+        assertThrows(CommandException.class, () -> timeTableAddCommand.execute(modelStub),
+            TimeTableAddCommand.MESSAGE_EXISTING_SEMESTER);
+    }
+
+    @Test
+    public void equals() {
+        TimeTableAddCommand timeTableAddYear1SemOne = new TimeTableAddCommand(YEAR_1_SEM_ONE);
+        TimeTableAddCommand timeTableAddYear1SemTwo = new TimeTableAddCommand(YEAR_1_SEM_TWO);
+        TimeTableAddCommand timeTableAddYear2SemOne = new TimeTableAddCommand(YEAR_2_SEM_ONE);
+
+        // same object -> returns true
+        assertTrue(timeTableAddYear1SemOne.equals(timeTableAddYear1SemOne));
+
+        // same values -> returns true
+        TimeTableAddCommand timeTableAddYear1SemOneCopy = new TimeTableAddCommand(YEAR_1_SEM_ONE);
+        assertTrue(timeTableAddYear1SemOne.equals(timeTableAddYear1SemOneCopy));
+
+        // different types -> returns false
+        assertFalse(timeTableAddYear1SemOne.equals(1));
+
+        // null -> returns false
+        assertFalse(timeTableAddYear1SemOne.equals(null));
+
+        // different StudentSemester -> returns false
+        assertFalse(timeTableAddYear1SemOne.equals(timeTableAddYear1SemTwo));
+        assertFalse(timeTableAddYear1SemOne.equals(timeTableAddYear2SemOne));
+        assertFalse(timeTableAddYear1SemTwo.equals(timeTableAddYear2SemOne));
+    }
+
+    /**
+     * A Model stub that always has an active student and always accept the timetable being added.
+     */
+    private class ModelStubAcceptingTimeTableAdded extends ModelStub {
+        final ArrayList<StudentSemester> studentSemestersAdded = new ArrayList<>();
+
+        @Override
+        public boolean hasActiveStudent() {
+            return true;
+        }
+
+        @Override
+        public boolean hasSemester(StudentSemester studentSemester) {
+            requireAllNonNull(studentSemester);
+            return studentSemestersAdded.stream().anyMatch(studentSemester::equals);
+        }
+
+        @Override
+        public void addSemesterTimeTable(StudentSemester studentSemester) {
+            requireAllNonNull(studentSemester);
+            studentSemestersAdded.add(studentSemester);
+        }
+
+        @Override
+        public ReadOnlyPlanner getPlanner() {
+            return new Planner();
+        }
+    }
+
+    /**
+     * A Model stub that always has an active student and contains a single timetable.
+     */
+    private class ModelStubWithTimeTable extends ModelStub {
+        private final StudentSemester studentSemester;
+
+        ModelStubWithTimeTable(StudentSemester studentSemester) {
+            requireAllNonNull(studentSemester);
+            this.studentSemester = studentSemester;
+        }
+
+        @Override
+        public boolean hasActiveStudent() {
+            return true;
+        }
+
+        @Override
+        public boolean hasSemester(StudentSemester studentSemester) {
+            requireAllNonNull(studentSemester);
+            return this.studentSemester.equals(studentSemester);
+        }
+    }
+
+    /**
+     * A Model stub that does not have an active student.
+     */
+    private class ModelStubNoActiveStudent extends ModelStub {
+        @Override
+        public boolean hasActiveStudent() {
+            return false;
+        }
+    }
+}
+//@@author

--- a/src/test/java/seedu/planner/logic/commands/timetable/TimeTableListCommandTest.java
+++ b/src/test/java/seedu/planner/logic/commands/timetable/TimeTableListCommandTest.java
@@ -1,0 +1,128 @@
+package seedu.planner.logic.commands.timetable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static seedu.planner.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.planner.testutil.TypicalStudentSemesters.YEAR_1_SEM_ONE;
+import static seedu.planner.testutil.TypicalStudentSemesters.YEAR_1_SEM_TWO;
+import static seedu.planner.testutil.TypicalStudentSemesters.YEAR_2_SEM_ONE;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.planner.commons.core.Messages;
+import seedu.planner.logic.commands.CommandResult;
+import seedu.planner.logic.commands.exceptions.CommandException;
+import seedu.planner.model.Model;
+import seedu.planner.model.ModelManager;
+import seedu.planner.model.Planner;
+import seedu.planner.model.UserPrefs;
+import seedu.planner.model.student.Student;
+import seedu.planner.model.student.TimeTable;
+import seedu.planner.model.student.TimeTableMap;
+import seedu.planner.model.time.StudentSemester;
+import seedu.planner.testutil.StudentBuilder;
+import seedu.planner.testutil.TypicalStudents;
+import seedu.planner.testutil.TypicalTimeTables;
+
+//@@author thetruevincentchow
+/**
+ * Contains integration tests (interaction with the Model) for TimeTableListCommand.
+ */
+public class TimeTableListCommandTest {
+    @Test
+    public void execute_showNonEmptyTimeTableList_success() {
+        Planner planner = new Planner();
+
+        TimeTableMap validTimeTableMap = TypicalTimeTables.getTypicalTimeTableMap();
+        Student validStudent = new StudentBuilder(TypicalStudents.ALICE)
+            .withTimeTableMap(validTimeTableMap).build();
+        planner.setStudents(Arrays.asList(validStudent));
+        planner.activateStudent(validStudent);
+
+
+        final String expectedFeedback = String.format(TimeTableListCommand.MESSAGE_SUCCESS,
+            validStudent, validStudent.getStudentSemesters());
+
+        Model model = new ModelManager(planner, new UserPrefs());
+        Model expectedModel = new ModelManager(model.getPlanner(), new UserPrefs());
+
+        assertCommandSuccess(new TimeTableListCommand(), model, expectedFeedback, expectedModel);
+    }
+
+    @Test
+    public void execute_showEmptyTimeTableList_success() {
+        Planner planner = new Planner();
+
+        TimeTableMap validTimeTableMap = TypicalTimeTables.getTypicalTimeTableMap();
+        Student validStudent = new StudentBuilder(TypicalStudents.ALICE).build();
+        planner.setStudents(Arrays.asList(validStudent));
+        planner.activateStudent(validStudent);
+
+        final String expectedFeedback = String.format(TimeTableListCommand.MESSAGE_SUCCESS, validStudent, "[]");
+
+        Model model = new ModelManager(planner, new UserPrefs());
+        Model expectedModel = new ModelManager(model.getPlanner(), new UserPrefs());
+
+        assertCommandSuccess(new TimeTableListCommand(), model, expectedFeedback, expectedModel);
+    }
+
+    @Test
+    public void execute_noActiveStudent_throwsCommandException() {
+        Model model = new ModelManager(TypicalStudents.getTypicalPlanner(), new UserPrefs());
+        model.activateStudent(null);
+        TimeTableListCommand timeTableListCommand = new TimeTableListCommand();
+
+        assertThrows(CommandException.class, () -> timeTableListCommand.execute(model),
+            Messages.MESSAGE_NO_STUDENT_ACTIVE);
+    }
+
+    /**
+     * Returns a {@link TimeTableMap} containing empty timetables for the specified {@code semesters}.
+     * @param semesters Any number of {@link StudentSemester}s
+     * @return {@link TimeTableMap} with empty timetables for specified semesters
+     */
+    private TimeTableMap timeTableMapWithSemesters(StudentSemester... semesters) {
+        TimeTableMap timeTableMap = new TimeTableMap();
+        for (StudentSemester semester : semesters) {
+            timeTableMap.put(semester, new TimeTable());
+        }
+        return timeTableMap;
+    }
+
+    /**
+     * Returns a Model which stores a single {@link Student} with empty timetables for the specified {@code semesters}.
+     * Ensures the student is active.
+     * @param semesters Any number of {@link StudentSemester}s
+     * @return {@link Model} with empty timetables for specified semesters
+     */
+    private Model modelWithStudentSemesters(StudentSemester... semesters) {
+        TimeTableMap timeTableMap = timeTableMapWithSemesters(semesters);
+        Student validStudent = new StudentBuilder(TypicalStudents.ALICE)
+            .withTimeTableMap(timeTableMap).build();
+        Planner planner = new Planner();
+        planner.setStudents(Arrays.asList(validStudent));
+        planner.activateStudent(validStudent);
+
+        return new ModelManager(planner, new UserPrefs());
+    }
+
+    /**
+     * Semesters for the timetables listed should be ordered by the semesters,
+     * independent of the insertion order of semesters.
+     */
+    @Test
+    public void execute_uniqueOrder_success() {
+        Model model1 = modelWithStudentSemesters(YEAR_1_SEM_ONE, YEAR_1_SEM_TWO, YEAR_2_SEM_ONE);
+        Model model2 = modelWithStudentSemesters(YEAR_2_SEM_ONE, YEAR_1_SEM_TWO, YEAR_1_SEM_ONE);
+
+        Model expectedModel1 = new ModelManager(model1.getPlanner(), new UserPrefs());
+        Model expectedModel2 = new ModelManager(model2.getPlanner(), new UserPrefs());
+
+        CommandResult commandResult1 = assertCommandSuccess(new TimeTableListCommand(), model1, expectedModel1);
+        CommandResult commandResult2 = assertCommandSuccess(new TimeTableListCommand(), model2, expectedModel2);
+        assertEquals(commandResult1, commandResult2);
+    }
+}
+//@@author

--- a/src/test/java/seedu/planner/logic/commands/timetable/TimeTableRemoveCommandTest.java
+++ b/src/test/java/seedu/planner/logic/commands/timetable/TimeTableRemoveCommandTest.java
@@ -1,0 +1,114 @@
+package seedu.planner.logic.commands.timetable;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.planner.commons.core.Messages.MESSAGE_INVALID_SEMESTER;
+import static seedu.planner.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.planner.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.planner.testutil.TypicalStudentSemesters.YEAR_1_SEM_ONE;
+import static seedu.planner.testutil.TypicalStudentSemesters.YEAR_1_SEM_TWO;
+import static seedu.planner.testutil.TypicalStudentSemesters.YEAR_2_SEM_ONE;
+import static seedu.planner.testutil.TypicalStudentSemesters.YEAR_6_SEM_ONE;
+import static seedu.planner.testutil.TypicalStudents.getTypicalPlannerWithTimeTables;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.planner.commons.core.Messages;
+import seedu.planner.logic.commands.exceptions.CommandException;
+import seedu.planner.model.Model;
+import seedu.planner.model.ModelManager;
+import seedu.planner.model.UserPrefs;
+import seedu.planner.model.student.Student;
+import seedu.planner.model.time.StudentSemester;
+import seedu.planner.testutil.TypicalStudents;
+
+//@@author thetruevincentchow
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code TimeTableRemoveCommand}.
+ */
+public class TimeTableRemoveCommandTest {
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalPlannerWithTimeTables(), new UserPrefs());
+        expectedModel = new ModelManager(getTypicalPlannerWithTimeTables(), new UserPrefs());
+
+        // failure of this precondition does not indicate test failure
+        assert !model.getStudentList().isEmpty();
+        assert !expectedModel.getStudentList().isEmpty();
+
+        Student validStudent = model.getStudentList().get(0);
+
+        model.activateStudent(validStudent);
+        expectedModel.activateStudent(validStudent);
+
+        // failure of this precondition does not indicate test failure
+        assert !model.getStudentSemesters().isEmpty();
+        assert !expectedModel.getStudentSemesters().isEmpty();
+    }
+
+    @Test
+    public void execute_validStudentSemester_success() {
+        StudentSemester studentSemesterToRemove = model.getStudentSemesters().get(0);
+        TimeTableRemoveCommand timeTableRemoveCommand = new TimeTableRemoveCommand(studentSemesterToRemove);
+
+        String expectedMessage = String.format(TimeTableRemoveCommand.MESSAGE_REMOVE_TIMETABLE_SUCCESS,
+            studentSemesterToRemove);
+
+        expectedModel.removeSemesterTimeTable(studentSemesterToRemove);
+        assertCommandSuccess(timeTableRemoveCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_noActiveStudent_throwsCommandException() {
+        Model model = new ModelManager(TypicalStudents.getTypicalPlanner(), new UserPrefs());
+        model.activateStudent(null);
+        TimeTableRemoveCommand timeTableRemoveCommand = new TimeTableRemoveCommand(YEAR_1_SEM_ONE);
+
+        assertThrows(CommandException.class, () -> timeTableRemoveCommand.execute(model),
+            Messages.MESSAGE_NO_STUDENT_ACTIVE);
+    }
+
+    @Test
+    public void execute_invalidStudentSemester_throwsCommandException() {
+        StudentSemester outOfBoundStudentSemester = YEAR_6_SEM_ONE;
+
+        // failure of this precondition does not indicate test failure
+        assert !model.getStudentSemesters().contains(outOfBoundStudentSemester);
+
+        TimeTableRemoveCommand timeTableRemoveCommand = new TimeTableRemoveCommand(outOfBoundStudentSemester);
+        assertCommandFailure(timeTableRemoveCommand, model, String.format(MESSAGE_INVALID_SEMESTER,
+            outOfBoundStudentSemester));
+    }
+
+    @Test
+    public void equals() {
+        TimeTableRemoveCommand timeTableRemoveYear1SemOne = new TimeTableRemoveCommand(YEAR_1_SEM_ONE);
+        TimeTableRemoveCommand timeTableRemoveYear1SemTwo = new TimeTableRemoveCommand(YEAR_1_SEM_TWO);
+        TimeTableRemoveCommand timeTableRemoveYear2SemOne = new TimeTableRemoveCommand(YEAR_2_SEM_ONE);
+
+        // same object -> returns true
+        assertTrue(timeTableRemoveYear1SemOne.equals(timeTableRemoveYear1SemOne));
+
+        // same values -> returns true
+        TimeTableRemoveCommand timeTableRemoveYear1SemOneCopy = new TimeTableRemoveCommand(YEAR_1_SEM_ONE);
+        assertTrue(timeTableRemoveYear1SemOne.equals(timeTableRemoveYear1SemOneCopy));
+
+        // different types -> returns false
+        assertFalse(timeTableRemoveYear1SemOne.equals(1));
+
+        // null -> returns false
+        assertFalse(timeTableRemoveYear1SemOne.equals(null));
+
+        // different StudentSemester -> returns false
+        assertFalse(timeTableRemoveYear1SemOne.equals(timeTableRemoveYear1SemTwo));
+        assertFalse(timeTableRemoveYear1SemOne.equals(timeTableRemoveYear2SemOne));
+        assertFalse(timeTableRemoveYear1SemTwo.equals(timeTableRemoveYear2SemOne));
+    }
+}
+//@@author

--- a/src/test/java/seedu/planner/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/planner/logic/parser/ParserUtilTest.java
@@ -3,7 +3,7 @@ package seedu.planner.logic.parser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.planner.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.planner.testutil.Assert.assertThrows;
-import static seedu.planner.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.planner.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
 
 import org.junit.jupiter.api.Test;
 
@@ -31,10 +31,10 @@ public class ParserUtilTest {
     @Test
     public void parseIndex_validInput_success() throws Exception {
         // No whitespaces
-        assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("1"));
+        assertEquals(INDEX_FIRST_STUDENT, ParserUtil.parseIndex("1"));
 
         // Leading and trailing whitespaces
-        assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("  1  "));
+        assertEquals(INDEX_FIRST_STUDENT, ParserUtil.parseIndex("  1  "));
     }
 
     @Test

--- a/src/test/java/seedu/planner/logic/parser/exemptions/ExemptAddCommandParserTest.java
+++ b/src/test/java/seedu/planner/logic/parser/exemptions/ExemptAddCommandParserTest.java
@@ -1,0 +1,40 @@
+package seedu.planner.logic.parser.exemptions;
+
+import static seedu.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.planner.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.planner.logic.commands.exemptions.ExemptAddCommand;
+import seedu.planner.model.module.ModuleCode;
+
+//@@author thetruevincentchow
+class ExemptAddCommandParserTest {
+    private ExemptAddCommandParser parser = new ExemptAddCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsAddCommand() {
+        assertParseSuccess(parser, "CS2040", new ExemptAddCommand(new ModuleCode("CS2040")));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        // empty
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            ExemptAddCommand.MESSAGE_USAGE));
+
+        // whitespace only
+        assertParseFailure(parser, PREAMBLE_WHITESPACE, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            ExemptAddCommand.MESSAGE_USAGE));
+
+        // invalid exempt code format
+        assertParseFailure(parser, "a  b", ModuleCode.MESSAGE_CONSTRAINTS);
+
+        assertParseFailure(parser, "a\tb", ModuleCode.MESSAGE_CONSTRAINTS);
+
+        assertParseFailure(parser, "-4asdf++!", ModuleCode.MESSAGE_CONSTRAINTS);
+    }
+}
+//@@author

--- a/src/test/java/seedu/planner/logic/parser/exemptions/ExemptCommandParserTest.java
+++ b/src/test/java/seedu/planner/logic/parser/exemptions/ExemptCommandParserTest.java
@@ -1,0 +1,44 @@
+package seedu.planner.logic.parser.exemptions;
+
+import static seedu.planner.commons.core.Messages.MESSAGE_UNKNOWN_SUBCOMMAND;
+import static seedu.planner.logic.commands.CommandTestUtil.INVALID_SUBCOMMAND;
+import static seedu.planner.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.planner.logic.commands.exemptions.ExemptAddCommand;
+import seedu.planner.logic.commands.exemptions.ExemptCommand;
+import seedu.planner.logic.commands.exemptions.ExemptRemoveCommand;
+import seedu.planner.model.module.ModuleCode;
+
+//@@author thetruevincentchow
+class ExemptCommandParserTest {
+    private ExemptCommandParser parser = new ExemptCommandParser();
+
+    @Test
+    public void parse_validArgs_success() {
+        assertParseSuccess(parser, "add CS2040", new ExemptAddCommand(new ModuleCode("CS2040")));
+
+        assertParseSuccess(parser, "remove  CS2040", new ExemptRemoveCommand(new ModuleCode("CS2040")));
+    }
+
+    @Test
+    public void parse_subCommandMissing_failure() {
+        assertParseFailure(parser, "", String.format(MESSAGE_UNKNOWN_SUBCOMMAND, ExemptCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, PREAMBLE_WHITESPACE, String.format(MESSAGE_UNKNOWN_SUBCOMMAND,
+            ExemptCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_subCommandInvalid_failure() {
+        assertParseFailure(parser, INVALID_SUBCOMMAND, String.format(MESSAGE_UNKNOWN_SUBCOMMAND,
+            ExemptCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, PREAMBLE_WHITESPACE + INVALID_SUBCOMMAND, String.format(MESSAGE_UNKNOWN_SUBCOMMAND,
+            ExemptCommand.MESSAGE_USAGE));
+    }
+}
+//@@author

--- a/src/test/java/seedu/planner/logic/parser/exemptions/ExemptRemoveCommandParserTest.java
+++ b/src/test/java/seedu/planner/logic/parser/exemptions/ExemptRemoveCommandParserTest.java
@@ -1,0 +1,40 @@
+package seedu.planner.logic.parser.exemptions;
+
+import static seedu.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.planner.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.planner.logic.commands.exemptions.ExemptRemoveCommand;
+import seedu.planner.model.module.ModuleCode;
+
+//@@author thetruevincentchow
+class ExemptRemoveCommandParserTest {
+    private ExemptRemoveCommandParser parser = new ExemptRemoveCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsRemoveCommand() {
+        assertParseSuccess(parser, "CS2040", new ExemptRemoveCommand(new ModuleCode("CS2040")));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        // empty
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            ExemptRemoveCommand.MESSAGE_USAGE));
+
+        // whitespace only
+        assertParseFailure(parser, PREAMBLE_WHITESPACE, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            ExemptRemoveCommand.MESSAGE_USAGE));
+
+        // invalid exempt code format
+        assertParseFailure(parser, "a  b", ModuleCode.MESSAGE_CONSTRAINTS);
+
+        assertParseFailure(parser, "a\tb", ModuleCode.MESSAGE_CONSTRAINTS);
+
+        assertParseFailure(parser, "-4asdf++!", ModuleCode.MESSAGE_CONSTRAINTS);
+    }
+}
+//@@author

--- a/src/test/java/seedu/planner/logic/parser/module/ModuleAddCommandParserTest.java
+++ b/src/test/java/seedu/planner/logic/parser/module/ModuleAddCommandParserTest.java
@@ -1,0 +1,40 @@
+package seedu.planner.logic.parser.module;
+
+import static seedu.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.planner.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.planner.logic.commands.module.ModuleAddCommand;
+import seedu.planner.model.module.ModuleCode;
+
+//@@author thetruevincentchow
+class ModuleAddCommandParserTest {
+    private ModuleAddCommandParser parser = new ModuleAddCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsAddCommand() {
+        assertParseSuccess(parser, "CS2040", new ModuleAddCommand(new ModuleCode("CS2040")));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        // empty
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            ModuleAddCommand.MESSAGE_USAGE));
+
+        // whitespace only
+        assertParseFailure(parser, PREAMBLE_WHITESPACE, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            ModuleAddCommand.MESSAGE_USAGE));
+
+        // invalid module code format
+        assertParseFailure(parser, "a  b", ModuleCode.MESSAGE_CONSTRAINTS);
+
+        assertParseFailure(parser, "a\tb", ModuleCode.MESSAGE_CONSTRAINTS);
+
+        assertParseFailure(parser, "-4asdf++!", ModuleCode.MESSAGE_CONSTRAINTS);
+    }
+}
+//@@author

--- a/src/test/java/seedu/planner/logic/parser/module/ModuleCommandParserTest.java
+++ b/src/test/java/seedu/planner/logic/parser/module/ModuleCommandParserTest.java
@@ -1,0 +1,51 @@
+package seedu.planner.logic.parser.module;
+
+import static seedu.planner.commons.core.Messages.MESSAGE_UNKNOWN_SUBCOMMAND;
+import static seedu.planner.logic.commands.CommandTestUtil.INVALID_SUBCOMMAND;
+import static seedu.planner.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.planner.logic.commands.module.ModuleAddCommand;
+import seedu.planner.logic.commands.module.ModuleCommand;
+import seedu.planner.logic.commands.module.ModuleGradeSetCommand;
+import seedu.planner.logic.commands.module.ModuleGradeViewCommand;
+import seedu.planner.logic.commands.module.ModuleRemoveCommand;
+import seedu.planner.model.grades.LetterGrade;
+import seedu.planner.model.module.ModuleCode;
+
+//@@author thetruevincentchow
+class ModuleCommandParserTest {
+    private ModuleCommandParser parser = new ModuleCommandParser();
+
+    @Test
+    public void parse_validArgs_success() {
+        assertParseSuccess(parser, "add CS2040", new ModuleAddCommand(new ModuleCode("CS2040")));
+
+        assertParseSuccess(parser, "remove  CS2040", new ModuleRemoveCommand(new ModuleCode("CS2040")));
+
+        assertParseSuccess(parser, "grade  CS2040", new ModuleGradeViewCommand(new ModuleCode("CS2040")));
+        assertParseSuccess(parser, "grade  CS2040  grade/A-", new ModuleGradeSetCommand(new ModuleCode("CS2040"),
+            LetterGrade.A_MINUS));
+    }
+
+    @Test
+    public void parse_subCommandMissing_failure() {
+        assertParseFailure(parser, "", String.format(MESSAGE_UNKNOWN_SUBCOMMAND, ModuleCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, PREAMBLE_WHITESPACE, String.format(MESSAGE_UNKNOWN_SUBCOMMAND,
+            ModuleCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_subCommandInvalid_failure() {
+        assertParseFailure(parser, INVALID_SUBCOMMAND, String.format(MESSAGE_UNKNOWN_SUBCOMMAND,
+            ModuleCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, PREAMBLE_WHITESPACE + INVALID_SUBCOMMAND, String.format(MESSAGE_UNKNOWN_SUBCOMMAND,
+            ModuleCommand.MESSAGE_USAGE));
+    }
+}
+//@@author

--- a/src/test/java/seedu/planner/logic/parser/module/ModuleGradeCommandParserTest.java
+++ b/src/test/java/seedu/planner/logic/parser/module/ModuleGradeCommandParserTest.java
@@ -1,0 +1,60 @@
+package seedu.planner.logic.parser.module;
+
+import static seedu.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.planner.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.planner.logic.commands.module.ModuleGradeCommand;
+import seedu.planner.logic.commands.module.ModuleGradeSetCommand;
+import seedu.planner.logic.commands.module.ModuleGradeViewCommand;
+import seedu.planner.model.grades.LetterGrade;
+import seedu.planner.model.module.ModuleCode;
+
+//@@author thetruevincentchow
+class ModuleGradeCommandParserTest {
+    private ModuleGradeCommandParser parser = new ModuleGradeCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsAddCommand() {
+        assertParseSuccess(parser, "CS2040", new ModuleGradeViewCommand(new ModuleCode("CS2040")));
+
+        assertParseSuccess(parser, "CS2040     grade/A+",
+            new ModuleGradeSetCommand(new ModuleCode("CS2040"), LetterGrade.A_PLUS));
+        assertParseSuccess(parser, "CS2040    grade/EXE",
+            new ModuleGradeSetCommand(new ModuleCode("CS2040"), LetterGrade.EXE));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        // empty
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            ModuleGradeCommand.MESSAGE_USAGE));
+
+        // whitespace only
+        assertParseFailure(parser, PREAMBLE_WHITESPACE, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            ModuleGradeCommand.MESSAGE_USAGE));
+
+        // invalid module code format
+        assertParseFailure(parser, "a  b", ModuleCode.MESSAGE_CONSTRAINTS);
+
+        assertParseFailure(parser, "a\tb", ModuleCode.MESSAGE_CONSTRAINTS);
+
+        assertParseFailure(parser, "-4asdf++!", ModuleCode.MESSAGE_CONSTRAINTS);
+
+        // grade prefix present but argument empty
+        assertParseFailure(parser, "CS2040 grade/", LetterGrade.MESSAGE_CONSTRAINTS);
+
+        // grade invalid
+        assertParseFailure(parser, "CS2040 grade/EE EE", LetterGrade.MESSAGE_CONSTRAINTS);
+
+        assertParseFailure(parser, "CS2040 grade/F+", LetterGrade.MESSAGE_CONSTRAINTS);
+
+        // grade parameter occurs before module code
+        assertParseFailure(parser, "grade/A  CS2040", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            ModuleGradeCommand.MESSAGE_USAGE));
+    }
+}
+//@@author

--- a/src/test/java/seedu/planner/logic/parser/module/ModuleRemoveCommandParserTest.java
+++ b/src/test/java/seedu/planner/logic/parser/module/ModuleRemoveCommandParserTest.java
@@ -1,0 +1,40 @@
+package seedu.planner.logic.parser.module;
+
+import static seedu.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.planner.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.planner.logic.commands.module.ModuleRemoveCommand;
+import seedu.planner.model.module.ModuleCode;
+
+//@@author thetruevincentchow
+class ModuleRemoveCommandParserTest {
+    private ModuleRemoveCommandParser parser = new ModuleRemoveCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsRemoveCommand() {
+        assertParseSuccess(parser, "CS2040", new ModuleRemoveCommand(new ModuleCode("CS2040")));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        // empty
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            ModuleRemoveCommand.MESSAGE_USAGE));
+
+        // whitespace only
+        assertParseFailure(parser, PREAMBLE_WHITESPACE, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            ModuleRemoveCommand.MESSAGE_USAGE));
+
+        // invalid module code format
+        assertParseFailure(parser, "a  b", ModuleCode.MESSAGE_CONSTRAINTS);
+
+        assertParseFailure(parser, "a\tb", ModuleCode.MESSAGE_CONSTRAINTS);
+
+        assertParseFailure(parser, "-4asdf++!", ModuleCode.MESSAGE_CONSTRAINTS);
+    }
+}
+//@@author

--- a/src/test/java/seedu/planner/logic/parser/student/StudentActiveCommandParserTest.java
+++ b/src/test/java/seedu/planner/logic/parser/student/StudentActiveCommandParserTest.java
@@ -1,0 +1,43 @@
+package seedu.planner.logic.parser.student;
+
+import static seedu.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.planner.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.planner.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.planner.logic.commands.student.StudentActiveCommand;
+
+//@@author thetruevincentchow
+class StudentActiveCommandParserTest {
+    private StudentActiveCommandParser parser = new StudentActiveCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsActiveCommand() {
+        assertParseSuccess(parser, "1", new StudentActiveCommand(INDEX_FIRST_STUDENT));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            StudentActiveCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, PREAMBLE_WHITESPACE, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            StudentActiveCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            StudentActiveCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, "0", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            StudentActiveCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, "-1", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            StudentActiveCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, "+1", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            StudentActiveCommand.MESSAGE_USAGE));
+    }
+}
+//@@author

--- a/src/test/java/seedu/planner/logic/parser/student/StudentAddCommandParserTest.java
+++ b/src/test/java/seedu/planner/logic/parser/student/StudentAddCommandParserTest.java
@@ -1,0 +1,88 @@
+package seedu.planner.logic.parser.student;
+
+import static seedu.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.planner.logic.commands.CommandTestUtil.INVALID_MAJOR_DESC;
+import static seedu.planner.logic.commands.CommandTestUtil.MAJOR_DESC_CS;
+import static seedu.planner.logic.commands.CommandTestUtil.MAJOR_DESC_CS_LOWER;
+import static seedu.planner.logic.commands.CommandTestUtil.MAJOR_DESC_IS;
+import static seedu.planner.logic.commands.CommandTestUtil.NAME_DESC_ALICE;
+import static seedu.planner.logic.commands.CommandTestUtil.NAME_DESC_BOB;
+import static seedu.planner.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.planner.logic.commands.CommandTestUtil.VALID_MAJOR_CS;
+import static seedu.planner.logic.commands.CommandTestUtil.VALID_NAME_ALICE;
+import static seedu.planner.logic.parser.CliSyntax.PREFIX_MAJOR;
+import static seedu.planner.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.planner.logic.commands.student.StudentAddCommand;
+import seedu.planner.model.student.Major;
+import seedu.planner.model.student.Name;
+import seedu.planner.model.student.Student;
+import seedu.planner.model.util.SampleDataUtil;
+import seedu.planner.testutil.StudentBuilder;
+
+//@@author thetruevincentchow
+class StudentAddCommandParserTest {
+    private StudentAddCommandParser parser = new StudentAddCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        Student expectedStudent = new StudentBuilder()
+            .withName(VALID_NAME_ALICE).withMajor(VALID_MAJOR_CS)
+            .withTimeTableMap(SampleDataUtil.getSampleTimeTableMap()).build();
+
+        // whitespace in preamble, all fields present
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_ALICE + MAJOR_DESC_CS,
+            new StudentAddCommand(expectedStudent));
+
+        // lowercase major
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_ALICE + MAJOR_DESC_CS_LOWER,
+            new StudentAddCommand(expectedStudent));
+
+        // multiple name prefixes
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + NAME_DESC_ALICE
+            + MAJOR_DESC_CS_LOWER, new StudentAddCommand(expectedStudent));
+
+        // multiple major prefixes
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + NAME_DESC_ALICE
+            + MAJOR_DESC_IS + MAJOR_DESC_CS_LOWER, new StudentAddCommand(expectedStudent));
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        // empty arguments
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT, StudentAddCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, PREAMBLE_WHITESPACE, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            StudentAddCommand.MESSAGE_USAGE));
+
+        // name not present
+        assertParseFailure(parser, MAJOR_DESC_CS_LOWER, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            StudentAddCommand.MESSAGE_USAGE));
+
+        // major not present
+        assertParseFailure(parser, NAME_DESC_ALICE, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            StudentAddCommand.MESSAGE_USAGE));
+
+        // name prefix present but empty argument
+        assertParseFailure(parser, PREFIX_NAME + " " + MAJOR_DESC_IS, Name.MESSAGE_CONSTRAINTS);
+
+        // major prefix present but empty argument
+        assertParseFailure(parser, NAME_DESC_ALICE + " " + PREFIX_MAJOR + PREAMBLE_WHITESPACE,
+            Major.MESSAGE_CONSTRAINTS);
+
+        // name and major prefixes present but both have empty arguments
+        assertParseFailure(parser, PREFIX_NAME + " " + PREFIX_MAJOR, Name.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_compulsoryFieldInvalid_failure() {
+        // major invalid
+        assertParseFailure(parser, PREAMBLE_WHITESPACE + NAME_DESC_ALICE + INVALID_MAJOR_DESC,
+            Major.MESSAGE_CONSTRAINTS);
+    }
+}
+//@@author

--- a/src/test/java/seedu/planner/logic/parser/student/StudentCommandParserTest.java
+++ b/src/test/java/seedu/planner/logic/parser/student/StudentCommandParserTest.java
@@ -1,0 +1,88 @@
+package seedu.planner.logic.parser.student;
+
+import static seedu.planner.commons.core.Messages.MESSAGE_UNKNOWN_SUBCOMMAND;
+import static seedu.planner.logic.commands.CommandTestUtil.INVALID_SUBCOMMAND;
+import static seedu.planner.logic.commands.CommandTestUtil.MAJOR_DESC_CS;
+import static seedu.planner.logic.commands.CommandTestUtil.NAME_DESC_ALICE;
+import static seedu.planner.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.planner.logic.commands.CommandTestUtil.VALID_MAJOR_CS;
+import static seedu.planner.logic.commands.CommandTestUtil.VALID_NAME_ALICE;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.planner.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.planner.logic.commands.student.StudentActiveCommand;
+import seedu.planner.logic.commands.student.StudentAddCommand;
+import seedu.planner.logic.commands.student.StudentCommand;
+import seedu.planner.logic.commands.student.StudentGradeCommand;
+import seedu.planner.logic.commands.student.StudentListCommand;
+import seedu.planner.logic.commands.student.StudentRemoveCommand;
+import seedu.planner.model.student.Student;
+import seedu.planner.model.util.SampleDataUtil;
+import seedu.planner.testutil.StudentBuilder;
+
+//@@author thetruevincentchow
+class StudentCommandParserTest {
+    private StudentCommandParser parser = new StudentCommandParser();
+
+    @Test
+    public void parse_validAddCommand_success() {
+        Student expectedStudent = new StudentBuilder()
+            .withName(VALID_NAME_ALICE).withMajor(VALID_MAJOR_CS)
+            .withTimeTableMap(SampleDataUtil.getSampleTimeTableMap()).build();
+
+        // whitespace in preamble, all fields present
+        assertParseSuccess(parser, "add " + PREAMBLE_WHITESPACE + NAME_DESC_ALICE + MAJOR_DESC_CS,
+            new StudentAddCommand(expectedStudent));
+    }
+
+    @Test
+    public void parse_validRemoveCommand_success() {
+        assertParseSuccess(parser, "remove 1", new StudentRemoveCommand(INDEX_FIRST_STUDENT));
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + "remove 1", new StudentRemoveCommand(INDEX_FIRST_STUDENT));
+    }
+
+    @Test
+    public void parse_validActiveCommand_success() {
+        assertParseSuccess(parser, "active 1", new StudentActiveCommand(INDEX_FIRST_STUDENT));
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + "active 1", new StudentActiveCommand(INDEX_FIRST_STUDENT));
+    }
+
+    @Test
+    public void parse_validListCommand_success() {
+        assertParseSuccess(parser, "list", new StudentListCommand());
+
+        // any text is allowed after "list "
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + "list" + " fajslkfjalk",
+            new StudentListCommand());
+    }
+
+    @Test
+    public void parse_validGradeCommand_success() {
+        assertParseSuccess(parser, "grade", new StudentGradeCommand());
+
+        // any text is allowed after "grade "
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + "grade" + " fajslkfjalk",
+            new StudentGradeCommand());
+    }
+
+    @Test
+    public void parse_subCommandMissing_failure() {
+        assertParseFailure(parser, "", String.format(MESSAGE_UNKNOWN_SUBCOMMAND, StudentCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, PREAMBLE_WHITESPACE, String.format(MESSAGE_UNKNOWN_SUBCOMMAND,
+            StudentCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_subCommandInvalid_failure() {
+        assertParseFailure(parser, INVALID_SUBCOMMAND, String.format(MESSAGE_UNKNOWN_SUBCOMMAND,
+            StudentCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, PREAMBLE_WHITESPACE + INVALID_SUBCOMMAND, String.format(MESSAGE_UNKNOWN_SUBCOMMAND,
+            StudentCommand.MESSAGE_USAGE));
+    }
+}
+//@@author

--- a/src/test/java/seedu/planner/logic/parser/student/StudentRemoveCommandParserTest.java
+++ b/src/test/java/seedu/planner/logic/parser/student/StudentRemoveCommandParserTest.java
@@ -1,0 +1,43 @@
+package seedu.planner.logic.parser.student;
+
+import static seedu.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.planner.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.planner.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.planner.logic.commands.student.StudentRemoveCommand;
+
+//@@author thetruevincentchow
+class StudentRemoveCommandParserTest {
+    private StudentRemoveCommandParser parser = new StudentRemoveCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsRemoveCommand() {
+        assertParseSuccess(parser, "1", new StudentRemoveCommand(INDEX_FIRST_STUDENT));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            StudentRemoveCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, PREAMBLE_WHITESPACE, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            StudentRemoveCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            StudentRemoveCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, "0", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            StudentRemoveCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, "-1", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            StudentRemoveCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, "+1", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            StudentRemoveCommand.MESSAGE_USAGE));
+    }
+}
+//@@author

--- a/src/test/java/seedu/planner/logic/parser/timetable/TimeTableActiveCommandParserTest.java
+++ b/src/test/java/seedu/planner/logic/parser/timetable/TimeTableActiveCommandParserTest.java
@@ -1,0 +1,82 @@
+package seedu.planner.logic.parser.timetable;
+
+import static seedu.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.planner.logic.commands.CommandTestUtil.DEGREE_YEAR_DESC;
+import static seedu.planner.logic.commands.CommandTestUtil.INVALID_TIMETABLE_SEM_DESC;
+import static seedu.planner.logic.commands.CommandTestUtil.INVALID_TIMETABLE_YEAR_DESC;
+import static seedu.planner.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.planner.logic.commands.CommandTestUtil.SEM_DESC;
+import static seedu.planner.logic.parser.CliSyntax.PREFIX_STUDENT_SEM;
+import static seedu.planner.logic.parser.CliSyntax.PREFIX_STUDENT_YEAR;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.planner.logic.commands.timetable.TimeTableActiveCommand;
+import seedu.planner.model.time.DegreeYear;
+import seedu.planner.model.time.Semester;
+import seedu.planner.model.time.SemesterYear;
+import seedu.planner.model.time.StudentSemester;
+
+//@@author thetruevincentchow
+class TimeTableActiveCommandParserTest {
+    private TimeTableActiveCommandParser parser = new TimeTableActiveCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        StudentSemester expectedSemester = new StudentSemester(new SemesterYear(Semester.SPECIAL_ONE), 1);
+
+        // whitespace in preamble, all fields present
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + DEGREE_YEAR_DESC + SEM_DESC,
+            new TimeTableActiveCommand(expectedSemester));
+
+        // arguments swapped
+        assertParseSuccess(parser, SEM_DESC + DEGREE_YEAR_DESC,
+            new TimeTableActiveCommand(expectedSemester));
+
+        // multiple prefixes
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + DEGREE_YEAR_DESC + DEGREE_YEAR_DESC
+            + SEM_DESC, new TimeTableActiveCommand(expectedSemester));
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        // empty arguments
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            TimeTableActiveCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, PREAMBLE_WHITESPACE, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            TimeTableActiveCommand.MESSAGE_USAGE));
+
+        // semester not present
+        assertParseFailure(parser, DEGREE_YEAR_DESC, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            TimeTableActiveCommand.MESSAGE_USAGE));
+
+        // degree year not present
+        assertParseFailure(parser, SEM_DESC, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            TimeTableActiveCommand.MESSAGE_USAGE));
+
+        // semester prefix present but empty argument
+        assertParseFailure(parser, PREFIX_STUDENT_SEM + " " + DEGREE_YEAR_DESC, Semester.MESSAGE_CONSTRAINTS);
+
+        // degree year prefix present but empty argument
+        assertParseFailure(parser, SEM_DESC + " " + PREFIX_STUDENT_YEAR + PREAMBLE_WHITESPACE,
+            DegreeYear.MESSAGE_CONSTRAINTS);
+
+        // name and major prefixes present but both have empty arguments
+        assertParseFailure(parser, PREFIX_STUDENT_SEM + " " + PREFIX_STUDENT_YEAR, DegreeYear.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_compulsoryFieldInvalid_failure() {
+        // degree year invalid
+        assertParseFailure(parser, PREAMBLE_WHITESPACE + INVALID_TIMETABLE_YEAR_DESC,
+            DegreeYear.MESSAGE_CONSTRAINTS);
+
+        // semester invalid
+        assertParseFailure(parser, PREAMBLE_WHITESPACE + INVALID_TIMETABLE_SEM_DESC,
+            Semester.MESSAGE_CONSTRAINTS);
+    }
+}
+//@@author

--- a/src/test/java/seedu/planner/logic/parser/timetable/TimeTableAddCommandParserTest.java
+++ b/src/test/java/seedu/planner/logic/parser/timetable/TimeTableAddCommandParserTest.java
@@ -1,0 +1,82 @@
+package seedu.planner.logic.parser.timetable;
+
+import static seedu.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.planner.logic.commands.CommandTestUtil.DEGREE_YEAR_DESC;
+import static seedu.planner.logic.commands.CommandTestUtil.INVALID_TIMETABLE_SEM_DESC;
+import static seedu.planner.logic.commands.CommandTestUtil.INVALID_TIMETABLE_YEAR_DESC;
+import static seedu.planner.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.planner.logic.commands.CommandTestUtil.SEM_DESC;
+import static seedu.planner.logic.parser.CliSyntax.PREFIX_STUDENT_SEM;
+import static seedu.planner.logic.parser.CliSyntax.PREFIX_STUDENT_YEAR;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.planner.logic.commands.timetable.TimeTableAddCommand;
+import seedu.planner.model.time.DegreeYear;
+import seedu.planner.model.time.Semester;
+import seedu.planner.model.time.SemesterYear;
+import seedu.planner.model.time.StudentSemester;
+
+//@@author thetruevincentchow
+class TimeTableAddCommandParserTest {
+    private TimeTableAddCommandParser parser = new TimeTableAddCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        StudentSemester expectedSemester = new StudentSemester(new SemesterYear(Semester.SPECIAL_ONE), 1);
+
+        // whitespace in preamble, all fields present
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + DEGREE_YEAR_DESC + SEM_DESC,
+            new TimeTableAddCommand(expectedSemester));
+
+        // arguments swapped
+        assertParseSuccess(parser, SEM_DESC + DEGREE_YEAR_DESC,
+            new TimeTableAddCommand(expectedSemester));
+
+        // multiple prefixes
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + DEGREE_YEAR_DESC + DEGREE_YEAR_DESC
+            + SEM_DESC, new TimeTableAddCommand(expectedSemester));
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        // empty arguments
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            TimeTableAddCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, PREAMBLE_WHITESPACE, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            TimeTableAddCommand.MESSAGE_USAGE));
+
+        // semester not present
+        assertParseFailure(parser, DEGREE_YEAR_DESC, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            TimeTableAddCommand.MESSAGE_USAGE));
+
+        // degree year not present
+        assertParseFailure(parser, SEM_DESC, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            TimeTableAddCommand.MESSAGE_USAGE));
+
+        // semester prefix present but empty argument
+        assertParseFailure(parser, PREFIX_STUDENT_SEM + " " + DEGREE_YEAR_DESC, Semester.MESSAGE_CONSTRAINTS);
+
+        // degree year prefix present but empty argument
+        assertParseFailure(parser, SEM_DESC + " " + PREFIX_STUDENT_YEAR + PREAMBLE_WHITESPACE,
+            DegreeYear.MESSAGE_CONSTRAINTS);
+
+        // name and major prefixes present but both have empty arguments
+        assertParseFailure(parser, PREFIX_STUDENT_SEM + " " + PREFIX_STUDENT_YEAR, DegreeYear.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_compulsoryFieldInvalid_failure() {
+        // degree year invalid
+        assertParseFailure(parser, PREAMBLE_WHITESPACE + INVALID_TIMETABLE_YEAR_DESC,
+            DegreeYear.MESSAGE_CONSTRAINTS);
+
+        // semester invalid
+        assertParseFailure(parser, PREAMBLE_WHITESPACE + INVALID_TIMETABLE_SEM_DESC,
+            Semester.MESSAGE_CONSTRAINTS);
+    }
+}
+//@@author

--- a/src/test/java/seedu/planner/logic/parser/timetable/TimeTableCommandParserTest.java
+++ b/src/test/java/seedu/planner/logic/parser/timetable/TimeTableCommandParserTest.java
@@ -1,0 +1,76 @@
+package seedu.planner.logic.parser.timetable;
+
+import static seedu.planner.commons.core.Messages.MESSAGE_UNKNOWN_SUBCOMMAND;
+import static seedu.planner.logic.commands.CommandTestUtil.DEGREE_YEAR_DESC;
+import static seedu.planner.logic.commands.CommandTestUtil.INVALID_SUBCOMMAND;
+import static seedu.planner.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.planner.logic.commands.CommandTestUtil.SEM_DESC;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.planner.logic.commands.timetable.TimeTableActiveCommand;
+import seedu.planner.logic.commands.timetable.TimeTableAddCommand;
+import seedu.planner.logic.commands.timetable.TimeTableCommand;
+import seedu.planner.logic.commands.timetable.TimeTableListCommand;
+import seedu.planner.logic.commands.timetable.TimeTableRemoveCommand;
+import seedu.planner.model.time.Semester;
+import seedu.planner.model.time.SemesterYear;
+import seedu.planner.model.time.StudentSemester;
+
+//@@author thetruevincentchow
+class TimeTableCommandParserTest {
+    private TimeTableCommandParser parser = new TimeTableCommandParser();
+    private StudentSemester expectedSemester = new StudentSemester(new SemesterYear(Semester.SPECIAL_ONE), 1);
+
+    @Test
+    public void parse_validAddCommand_success() {
+        // whitespace in preamble, all fields present
+        assertParseSuccess(parser, "add " + PREAMBLE_WHITESPACE + DEGREE_YEAR_DESC + SEM_DESC,
+            new TimeTableAddCommand(expectedSemester));
+    }
+
+    @Test
+    public void parse_validRemoveCommand_success() {
+        assertParseSuccess(parser, "remove " + SEM_DESC + DEGREE_YEAR_DESC,
+                new TimeTableRemoveCommand(expectedSemester));
+        assertParseSuccess(parser, "remove " + PREAMBLE_WHITESPACE + SEM_DESC + DEGREE_YEAR_DESC,
+            new TimeTableRemoveCommand(expectedSemester));
+    }
+
+    @Test
+    public void parse_validActiveCommand_success() {
+        assertParseSuccess(parser, "active " + SEM_DESC + DEGREE_YEAR_DESC,
+            new TimeTableActiveCommand(expectedSemester));
+        assertParseSuccess(parser, "active " + PREAMBLE_WHITESPACE + SEM_DESC + DEGREE_YEAR_DESC,
+            new TimeTableActiveCommand(expectedSemester));
+    }
+
+    @Test
+    public void parse_validListCommand_success() {
+        assertParseSuccess(parser, "list", new TimeTableListCommand());
+
+        // any text is allowed after "list "
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + "list" + " fajslkfjalk",
+            new TimeTableListCommand());
+    }
+
+    @Test
+    public void parse_subCommandMissing_failure() {
+        assertParseFailure(parser, "", String.format(MESSAGE_UNKNOWN_SUBCOMMAND, TimeTableCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, PREAMBLE_WHITESPACE, String.format(MESSAGE_UNKNOWN_SUBCOMMAND,
+            TimeTableCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_subCommandInvalid_failure() {
+        assertParseFailure(parser, INVALID_SUBCOMMAND, String.format(MESSAGE_UNKNOWN_SUBCOMMAND,
+            TimeTableCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, PREAMBLE_WHITESPACE + INVALID_SUBCOMMAND, String.format(MESSAGE_UNKNOWN_SUBCOMMAND,
+            TimeTableCommand.MESSAGE_USAGE));
+    }
+}
+//@@author

--- a/src/test/java/seedu/planner/logic/parser/timetable/TimeTableRemoveCommandParserTest.java
+++ b/src/test/java/seedu/planner/logic/parser/timetable/TimeTableRemoveCommandParserTest.java
@@ -1,0 +1,82 @@
+package seedu.planner.logic.parser.timetable;
+
+import static seedu.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.planner.logic.commands.CommandTestUtil.DEGREE_YEAR_DESC;
+import static seedu.planner.logic.commands.CommandTestUtil.INVALID_TIMETABLE_SEM_DESC;
+import static seedu.planner.logic.commands.CommandTestUtil.INVALID_TIMETABLE_YEAR_DESC;
+import static seedu.planner.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.planner.logic.commands.CommandTestUtil.SEM_DESC;
+import static seedu.planner.logic.parser.CliSyntax.PREFIX_STUDENT_SEM;
+import static seedu.planner.logic.parser.CliSyntax.PREFIX_STUDENT_YEAR;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.planner.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.planner.logic.commands.timetable.TimeTableRemoveCommand;
+import seedu.planner.model.time.DegreeYear;
+import seedu.planner.model.time.Semester;
+import seedu.planner.model.time.SemesterYear;
+import seedu.planner.model.time.StudentSemester;
+
+//@@author thetruevincentchow
+class TimeTableRemoveCommandParserTest {
+    private TimeTableRemoveCommandParser parser = new TimeTableRemoveCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        StudentSemester expectedSemester = new StudentSemester(new SemesterYear(Semester.SPECIAL_ONE), 1);
+
+        // whitespace in preamble, all fields present
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + DEGREE_YEAR_DESC + SEM_DESC,
+            new TimeTableRemoveCommand(expectedSemester));
+
+        // arguments swapped
+        assertParseSuccess(parser, SEM_DESC + DEGREE_YEAR_DESC,
+            new TimeTableRemoveCommand(expectedSemester));
+
+        // multiple prefixes
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + DEGREE_YEAR_DESC + DEGREE_YEAR_DESC
+            + SEM_DESC, new TimeTableRemoveCommand(expectedSemester));
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        // empty arguments
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            TimeTableRemoveCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, PREAMBLE_WHITESPACE, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            TimeTableRemoveCommand.MESSAGE_USAGE));
+
+        // semester not present
+        assertParseFailure(parser, DEGREE_YEAR_DESC, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            TimeTableRemoveCommand.MESSAGE_USAGE));
+
+        // degree year not present
+        assertParseFailure(parser, SEM_DESC, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            TimeTableRemoveCommand.MESSAGE_USAGE));
+
+        // semester prefix present but empty argument
+        assertParseFailure(parser, PREFIX_STUDENT_SEM + " " + DEGREE_YEAR_DESC, Semester.MESSAGE_CONSTRAINTS);
+
+        // degree year prefix present but empty argument
+        assertParseFailure(parser, SEM_DESC + " " + PREFIX_STUDENT_YEAR + PREAMBLE_WHITESPACE,
+            DegreeYear.MESSAGE_CONSTRAINTS);
+
+        // name and major prefixes present but both have empty arguments
+        assertParseFailure(parser, PREFIX_STUDENT_SEM + " " + PREFIX_STUDENT_YEAR, DegreeYear.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_compulsoryFieldInvalid_failure() {
+        // degree year invalid
+        assertParseFailure(parser, PREAMBLE_WHITESPACE + INVALID_TIMETABLE_YEAR_DESC,
+            DegreeYear.MESSAGE_CONSTRAINTS);
+
+        // semester invalid
+        assertParseFailure(parser, PREAMBLE_WHITESPACE + INVALID_TIMETABLE_SEM_DESC,
+            Semester.MESSAGE_CONSTRAINTS);
+    }
+}
+//@@author

--- a/src/test/java/seedu/planner/model/ModelStub.java
+++ b/src/test/java/seedu/planner/model/ModelStub.java
@@ -1,0 +1,198 @@
+package seedu.planner.model;
+
+import java.util.List;
+import java.util.Optional;
+
+import javafx.collections.ObservableList;
+import seedu.planner.commons.core.GuiSettings;
+import seedu.planner.model.grades.Grade;
+import seedu.planner.model.module.Lesson;
+import seedu.planner.model.module.ModuleCode;
+import seedu.planner.model.student.Enrollment;
+import seedu.planner.model.student.Student;
+import seedu.planner.model.student.TimeTable;
+import seedu.planner.model.time.StudentSemester;
+
+//@@author thetruevincentchow
+public class ModelStub implements Model {
+    @Override
+    public ReadOnlyUserPrefs getUserPrefs() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public GuiSettings getGuiSettings() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setGuiSettings(GuiSettings guiSettings) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyPlanner getPlanner() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setPlanner(Planner planner) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Student> getStudentList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasStudent(Student student) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public Student getActiveStudent() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void replaceActiveStudent(Student editedStudent) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void activateStudent(Student student) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void activateValidStudent() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addStudent(Student student) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void removeStudent(Student student) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public List<StudentSemester> getStudentSemesters() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<ModuleCode> getEnrolledModuleCodes() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasEnrollment(ModuleCode moduleCode) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addEnrollment(Enrollment enrollment) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void removeEnrollment(ModuleCode moduleCode) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void activateSemester(StudentSemester studentSemester) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public TimeTable getActiveTimeTable() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addSemesterTimeTable(StudentSemester studentSemester) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void removeSemesterTimeTable(StudentSemester studentSemester) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public Optional<Grade> getModuleGrade(ModuleCode moduleCode) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setModuleGrade(ModuleCode moduleCode, Grade grade) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<ModuleCode> getExemptedModulesList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addExemptedModule(ModuleCode moduleCode) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void removeExemptedModule(ModuleCode moduleCode) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasExemptedModule(ModuleCode moduleCode) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addLesson(Lesson lesson) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public List<Lesson> getLessons() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void removeLesson(Lesson removedLesson) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasLesson(Lesson lesson) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasSemester(StudentSemester studentSemester) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasActiveTimeTable() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasActiveStudent() {
+        throw new AssertionError("This method should not be called.");
+    }
+}
+//@@author

--- a/src/test/java/seedu/planner/testutil/StudentBuilder.java
+++ b/src/test/java/seedu/planner/testutil/StudentBuilder.java
@@ -1,8 +1,11 @@
 package seedu.planner.testutil;
 
+import java.util.ArrayList;
+
 import seedu.planner.model.student.Major;
 import seedu.planner.model.student.Name;
 import seedu.planner.model.student.Student;
+import seedu.planner.model.student.TimeTableMap;
 
 /**
  * A utility class to help with building Student objects.
@@ -11,17 +14,23 @@ import seedu.planner.model.student.Student;
  */
 public class StudentBuilder {
 
+    private static final String DEFAULT_NAME = "Alice";
+    private static final String DEFAULT_MAJOR = "CS";
+
     private Name name;
     private Major major;
+    private TimeTableMap timeTableMap;
 
     public StudentBuilder() {
-        name = null;
-        major = null;
+        name = new Name(DEFAULT_NAME);
+        major = new Major(DEFAULT_MAJOR);
+        timeTableMap = new TimeTableMap();
     }
 
     public StudentBuilder(Student student) {
         this.name = student.getName();
         this.major = student.getMajor();
+        this.timeTableMap = student.getTimeTableMap();
     }
 
     public StudentBuilder withName(Name name) {
@@ -29,7 +38,25 @@ public class StudentBuilder {
         return this;
     }
 
+    public StudentBuilder withName(String name) {
+        return withName(new Name(name));
+    }
+
+    public StudentBuilder withMajor(Major major) {
+        this.major = major;
+        return this;
+    }
+
+    public StudentBuilder withMajor(String major) {
+        return withMajor(new Major(major));
+    }
+
+    public StudentBuilder withTimeTableMap(TimeTableMap timeTableMap) {
+        this.timeTableMap = timeTableMap;
+        return this;
+    }
+
     public Student build() {
-        return new Student(name, major);
+        return new Student(name, major, timeTableMap, new ArrayList<>());
     }
 }

--- a/src/test/java/seedu/planner/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/planner/testutil/TypicalIndexes.java
@@ -6,7 +6,7 @@ import seedu.planner.commons.core.index.Index;
  * A utility class containing a list of {@code Index} objects to be used in tests.
  */
 public class TypicalIndexes {
-    public static final Index INDEX_FIRST_PERSON = Index.fromOneBased(1);
-    public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
-    public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
+    public static final Index INDEX_FIRST_STUDENT = Index.fromOneBased(1);
+    public static final Index INDEX_SECOND_STUDENT = Index.fromOneBased(2);
+    public static final Index INDEX_THIRD_STUDENT = Index.fromOneBased(3);
 }

--- a/src/test/java/seedu/planner/testutil/TypicalStudentSemesters.java
+++ b/src/test/java/seedu/planner/testutil/TypicalStudentSemesters.java
@@ -6,7 +6,7 @@ import seedu.planner.model.time.StudentSemester;
 
 //@@author thetruevincentchow
 /**
- * A utility class containing a list of {@code Index} objects to be used in tests.
+ * A utility class containing a list of {@code StudentSemester} objects to be used in tests.
  */
 public class TypicalStudentSemesters {
     public static final StudentSemester YEAR_1_SEM_ONE = new StudentSemester(new SemesterYear(Semester.ONE), 1);

--- a/src/test/java/seedu/planner/testutil/TypicalStudentSemesters.java
+++ b/src/test/java/seedu/planner/testutil/TypicalStudentSemesters.java
@@ -1,0 +1,17 @@
+package seedu.planner.testutil;
+
+import seedu.planner.model.time.Semester;
+import seedu.planner.model.time.SemesterYear;
+import seedu.planner.model.time.StudentSemester;
+
+//@@author thetruevincentchow
+/**
+ * A utility class containing a list of {@code Index} objects to be used in tests.
+ */
+public class TypicalStudentSemesters {
+    public static final StudentSemester YEAR_1_SEM_ONE = new StudentSemester(new SemesterYear(Semester.ONE), 1);
+    public static final StudentSemester YEAR_1_SEM_TWO = new StudentSemester(new SemesterYear(Semester.TWO), 1);
+    public static final StudentSemester YEAR_2_SEM_ONE = new StudentSemester(new SemesterYear(Semester.ONE), 2);
+    public static final StudentSemester YEAR_6_SEM_ONE = new StudentSemester(new SemesterYear(Semester.ONE), 6);
+}
+//@@author

--- a/src/test/java/seedu/planner/testutil/TypicalStudents.java
+++ b/src/test/java/seedu/planner/testutil/TypicalStudents.java
@@ -1,5 +1,7 @@
 package seedu.planner.testutil;
 
+import static seedu.planner.testutil.TypicalTimeTables.getTypicalTimeTableMap;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -9,7 +11,7 @@ import seedu.planner.model.student.Name;
 import seedu.planner.model.student.Student;
 
 /**
- * A utility class containing a list of {@code Module} objects to be used in tests.
+ * A utility class containing a list of {@code Student} objects to be used in tests.
  */
 public class TypicalStudents {
 
@@ -28,6 +30,19 @@ public class TypicalStudents {
         Planner planner = new Planner();
         for (Student student : getTypicalStudents()) {
             planner.addStudent(student);
+        }
+        return planner;
+    }
+
+    /**
+     * Returns an {@code Planner} with all the typical students.
+     */
+    public static Planner getTypicalPlannerWithTimeTables() {
+        Planner planner = new Planner();
+        for (Student student : getTypicalStudents()) {
+            planner.addStudent(new StudentBuilder(student)
+                .withTimeTableMap(getTypicalTimeTableMap())
+                .build());
         }
         return planner;
     }

--- a/src/test/java/seedu/planner/testutil/TypicalTimeTables.java
+++ b/src/test/java/seedu/planner/testutil/TypicalTimeTables.java
@@ -1,0 +1,32 @@
+package seedu.planner.testutil;
+
+import static seedu.planner.testutil.TypicalStudentSemesters.YEAR_1_SEM_ONE;
+
+import java.util.Optional;
+
+import seedu.planner.model.module.ModuleCode;
+import seedu.planner.model.student.Enrollment;
+import seedu.planner.model.student.TimeTable;
+import seedu.planner.model.student.TimeTableMap;
+
+//@@author thetruevincentchow
+/**
+ * A utility class containing a list of {@code TimeTable} and {@code TimeTableMap} objects to be used in tests.
+ */
+public class TypicalTimeTables {
+    private TypicalTimeTables() {
+    } // prevents instantiation
+
+    public static TimeTable getTypicalTimeTable() {
+        TimeTable timeTable = new TimeTable();
+        timeTable.addEnrollment(new Enrollment(new ModuleCode("CS2040"), Optional.empty(), 4));
+        return timeTable;
+    }
+
+    public static TimeTableMap getTypicalTimeTableMap() {
+        TimeTableMap timeTableMap = new TimeTableMap();
+        timeTableMap.put(YEAR_1_SEM_ONE, getTypicalTimeTable());
+        return timeTableMap;
+    }
+}
+//@@author


### PR DESCRIPTION
Many commands and their parsers now have integration tests. This increases code coverage significantly.

The behavior of `DegreeYear` is now consistent with its documentation in the code and the User Guide (i.e. valid from 1 to 6 inclusive).