### PR TITLE
Fix deserialisation and parsing bugs

### DIFF
--- a/src/main/java/seedu/planner/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/planner/logic/parser/ParserUtil.java
@@ -97,29 +97,16 @@ public class ParserUtil {
      */
     public static Semester parseSemester(String semester) throws ParseException {
         requireNonNull(semester);
-        try {
-            switch (semester) {
-            case "ONE":
-            case "1":
-                semester = "ONE";
-                break;
-            case "TWO":
-            case "2":
-                semester = "TWO";
-                break;
-            case "SPECIAL_ONE":
-            case "st1":
-                semester = "SPECIAL_TERM_ONE";
-                break;
-            case "SPECIAL_TWO":
-            case "st2":
-                semester = "SPECIAL_TERM_TWO";
-                break;
-            default:
-                throw new ParseException(Semester.MESSAGE_CONSTRAINTS);
-            }
-            return Semester.valueOf(semester);
-        } catch (IllegalArgumentException e) {
+        switch (semester.trim()) {
+        case "1":
+            return Semester.ONE;
+        case "2":
+            return Semester.TWO;
+        case "st1":
+            return Semester.SPECIAL_TERM_ONE;
+        case "st2":
+            return Semester.SPECIAL_TERM_TWO;
+        default:
             throw new ParseException(Semester.MESSAGE_CONSTRAINTS);
         }
     }
@@ -133,7 +120,7 @@ public class ParserUtil {
     public static Name parseName(String name) throws ParseException {
         requireNonNull(name);
         try {
-            return new Name(name);
+            return new Name(name.trim());
         } catch (IllegalArgumentException e) {
             throw new ParseException(Name.MESSAGE_CONSTRAINTS);
         }
@@ -148,7 +135,7 @@ public class ParserUtil {
     public static Major parseMajor(String major) throws ParseException {
         requireNonNull(major);
         try {
-            return new Major(major);
+            return new Major(major.trim());
         } catch (IllegalArgumentException e) {
             throw new ParseException(Major.MESSAGE_CONSTRAINTS);
         }
@@ -163,7 +150,7 @@ public class ParserUtil {
     public static LetterGrade parseLetterGrade(String letterGrade) throws ParseException {
         requireNonNull(letterGrade);
         try {
-            return LetterGrade.fromInputName(letterGrade);
+            return LetterGrade.fromInputName(letterGrade.trim());
         } catch (IllegalArgumentException e) {
             throw new ParseException(LetterGrade.MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/seedu/planner/model/module/ModuleCode.java
+++ b/src/main/java/seedu/planner/model/module/ModuleCode.java
@@ -18,6 +18,11 @@ public class ModuleCode {
      */
     public static final String VALIDATION_REGEX = "[\\p{Alnum}]+";
 
+    /**
+     * 2 to 3 case-insensitive letters, then exactly 4 digits, then at most one case-insensitive letter.
+     */
+    public static final String VALIDATION_REGEX_STRICT = "[\\p{Alpha}]{2,3}[\\p{Digit}]{4}[\\p{Alpha}]?";
+
     public final String value;
 
     public ModuleCode(String code) {
@@ -27,7 +32,8 @@ public class ModuleCode {
     }
 
     /**
-     * Returns true if a given string is a valid name.
+     * Returns true if a given string has the format of a valid module code.
+     * This does not validate if the module code corresponds to a module in NUS.
      */
     public static boolean isValidModuleCode(String test) {
         return test.matches(VALIDATION_REGEX);

--- a/src/main/java/seedu/planner/model/module/UniqueEnrollmentList.java
+++ b/src/main/java/seedu/planner/model/module/UniqueEnrollmentList.java
@@ -150,4 +150,8 @@ public class UniqueEnrollmentList implements Iterable<Enrollment> {
     public void removeIf(Predicate<? super Enrollment> predicate) {
         internalList.removeIf(predicate);
     }
+
+    public boolean hasModuleCode(ModuleCode moduleCode) {
+        return stream().anyMatch(enrollment -> enrollment.getModuleCode().equals(moduleCode));
+    }
 }

--- a/src/main/java/seedu/planner/model/student/TimeTable.java
+++ b/src/main/java/seedu/planner/model/student/TimeTable.java
@@ -24,6 +24,10 @@ public class TimeTable {
         enrollments.forEach(this.enrollments::add);
     }
 
+    public TimeTable(UniqueEnrollmentList enrollments) {
+        enrollments.forEach(this.enrollments::add);
+    }
+
     public void addEnrollment(Enrollment enrollment) {
         enrollments.add(enrollment);
     }
@@ -68,7 +72,7 @@ public class TimeTable {
     }
 
     public boolean hasModuleCode(ModuleCode moduleCode) {
-        return enrollments.stream().anyMatch(enrollment -> enrollment.getModuleCode().equals(moduleCode));
+        return enrollments.hasModuleCode(moduleCode);
     }
 
     public void removeModuleCode(ModuleCode moduleCode) {

--- a/src/main/java/seedu/planner/storage/JsonAdaptedEnrollment.java
+++ b/src/main/java/seedu/planner/storage/JsonAdaptedEnrollment.java
@@ -7,7 +7,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.planner.commons.exceptions.IllegalValueException;
 import seedu.planner.model.grades.Grade;
+import seedu.planner.model.module.ModuleCode;
 import seedu.planner.model.student.Enrollment;
+import seedu.planner.model.util.ModuleUtil;
 
 /**
  * Jackson-friendly version of {@link Enrollment}.
@@ -51,7 +53,22 @@ public class JsonAdaptedEnrollment {
      * @throws IllegalValueException if there were any data constraints violated in the adapted enrollment.
      */
     public Enrollment toModelType() throws IllegalValueException {
-        return new Enrollment(code.toModelType(), grade == null ? Optional.empty() : Optional.of(grade.toModelType()),
+        ModuleCode modelCode = code.toModelType();
+
+        // Check that module code exists in module database
+        if (!ModuleUtil.hasModuleWithCode(modelCode)) {
+            throw new IllegalValueException("Invalid module code: " + code);
+        }
+
+        // Ensure that the module credits is non-negative.
+        // NOTE: It is allowed for the module credits to differ from that in the module database.
+        //       This accounts for some special enrollment arrangements.
+        if (credit < 0) {
+            throw new IllegalValueException("Invalid credit: " + credit);
+        }
+
+        return new Enrollment(modelCode,
+                grade == null ? Optional.empty() : Optional.of(grade.toModelType()),
                 credit);
     }
 

--- a/src/main/java/seedu/planner/storage/JsonAdaptedGrade.java
+++ b/src/main/java/seedu/planner/storage/JsonAdaptedGrade.java
@@ -12,6 +12,9 @@ import seedu.planner.model.grades.LetterGrade;
  * Stores the {@code letterGrade} using its {@code inputName} instead of its {@code toString()} value.
  */
 public class JsonAdaptedGrade {
+
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Grade's %s field is missing!";
+
     protected final String letterGrade;
     protected final boolean isSu;
 
@@ -35,6 +38,12 @@ public class JsonAdaptedGrade {
      * @throws IllegalValueException if there were any data constraints violated in the adapted grade.
      */
     public Grade toModelType() throws IllegalValueException {
+
+        if (letterGrade == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    LetterGrade.class.getSimpleName()));
+        }
+
         try {
             return new Grade(LetterGrade.fromInputName(letterGrade), isSu);
         } catch (IllegalArgumentException ex) {

--- a/src/main/java/seedu/planner/storage/JsonAdaptedSemesterYear.java
+++ b/src/main/java/seedu/planner/storage/JsonAdaptedSemesterYear.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.planner.commons.exceptions.IllegalValueException;
-import seedu.planner.model.student.Name;
 import seedu.planner.model.time.Semester;
 import seedu.planner.model.time.SemesterYear;
 
@@ -43,9 +42,15 @@ public class JsonAdaptedSemesterYear {
     public SemesterYear toModelType() throws IllegalValueException {
 
         if (sem == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    Semester.class.getSimpleName()));
         }
-        final Semester modelSem = Semester.valueOf(sem);
+        Semester modelSem;
+        try {
+            modelSem = Semester.valueOf(sem);
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalValueException("Invalid Semester: " + sem);
+        }
         final int modelAcademicYear = academicYear;
 
         return new SemesterYear(modelSem, modelAcademicYear);

--- a/src/main/java/seedu/planner/storage/JsonAdaptedStudent.java
+++ b/src/main/java/seedu/planner/storage/JsonAdaptedStudent.java
@@ -28,6 +28,7 @@ import seedu.planner.model.student.Major;
 import seedu.planner.model.student.Name;
 import seedu.planner.model.student.Student;
 import seedu.planner.model.student.TimeTableMap;
+import seedu.planner.model.util.ModuleUtil;
 
 
 /**
@@ -109,7 +110,19 @@ class JsonAdaptedStudent {
         final List<ModuleCode> modelExemptedModules = new ArrayList<>();
         if (exemptedModules != null) {
             for (JsonAdaptedModuleCode moduleCode : exemptedModules) {
-                modelExemptedModules.add(moduleCode.toModelType());
+                ModuleCode modelCode = moduleCode.toModelType();
+
+                // Ignore module codes not present in the module database
+                if (!ModuleUtil.hasModuleWithCode(modelCode)) {
+                    continue;
+                }
+
+                // Ignore duplicate module codes
+                if (modelExemptedModules.contains(modelCode)) {
+                    continue;
+                }
+
+                modelExemptedModules.add(modelCode);
             }
         }
         GenericSpecialisation modelSpecialisation = null;

--- a/src/main/java/seedu/planner/storage/JsonAdaptedStudentSemester.java
+++ b/src/main/java/seedu/planner/storage/JsonAdaptedStudentSemester.java
@@ -44,9 +44,7 @@ public class JsonAdaptedStudentSemester {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     SemesterYear.class.getSimpleName()));
         }
-        /*if (!SemesterYear.isValidSemesterYear(semYear)) {
-            throw new IllegalValueException(SemesterYear.MESSAGE_CONSTRAINTS);
-        }*/
+
         final SemesterYear modelSemYear = semYear.toModelType();
 
         try {

--- a/src/main/java/seedu/planner/storage/JsonAdaptedTimeTable.java
+++ b/src/main/java/seedu/planner/storage/JsonAdaptedTimeTable.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import seedu.planner.commons.exceptions.IllegalValueException;
+import seedu.planner.model.module.UniqueEnrollmentList;
 import seedu.planner.model.student.Enrollment;
 import seedu.planner.model.student.TimeTable;
 
@@ -42,9 +43,17 @@ public class JsonAdaptedTimeTable {
      * @throws IllegalValueException if there were any data constraints violated in the adapted timetable.
      */
     public TimeTable toModelType() throws IllegalValueException {
-        final List<Enrollment> modelEnrollments = new ArrayList<>();
+        final UniqueEnrollmentList modelEnrollments = new UniqueEnrollmentList();
+
         for (JsonAdaptedEnrollment enrollment : enrollments) {
-            modelEnrollments.add(enrollment.toModelType());
+            Enrollment modelEnrollment = enrollment.toModelType();
+
+            // Enrollments with the same module code are not allowed
+            if (modelEnrollments.hasModuleCode(modelEnrollment.getCode())) {
+                throw new IllegalValueException("Duplicate enrollments in timetable");
+            }
+
+            modelEnrollments.add(modelEnrollment);
         }
         return new TimeTable(modelEnrollments);
     }

--- a/src/main/java/seedu/planner/storage/JsonAdaptedTimeTableMap.java
+++ b/src/main/java/seedu/planner/storage/JsonAdaptedTimeTableMap.java
@@ -47,9 +47,20 @@ public class JsonAdaptedTimeTableMap {
     public TimeTableMap toModelType() throws IllegalValueException {
         TimeTableMap map = new TimeTableMap();
         for (JsonAdaptedTimeTablePair timeTable : timeTables) {
-            Pair<JsonAdaptedStudentSemester, JsonAdaptedTimeTable> modelPair = timeTable.toModelType();
-            if (map.put(modelPair.getKey().toModelType(), modelPair.getValue().toModelType()) != null) {
-                throw new IllegalStateException("Duplicate key");
+            Pair<StudentSemester, TimeTable> modelPair;
+
+            // Ignore invalid pairs
+            try {
+                modelPair = timeTable.toModelType();
+            } catch (IllegalValueException ex) {
+                continue;
+            }
+
+            // However, if a pair is valid and the semester is already present, then throw an exception.
+            // NOTE: This allows any number of duplicate semesters in the list,
+            //       as long as only one of them has a valid corresponding timetable.
+            if (map.put(modelPair.getKey(), modelPair.getValue()) != null) {
+                throw new IllegalValueException("Duplicate key");
             }
         }
         return map;

--- a/src/main/java/seedu/planner/storage/JsonAdaptedTimeTablePair.java
+++ b/src/main/java/seedu/planner/storage/JsonAdaptedTimeTablePair.java
@@ -41,7 +41,7 @@ public class JsonAdaptedTimeTablePair {
      *
      * @throws IllegalValueException if there were any data constraints violated in the adapted timetable entry.
      */
-    public Pair<JsonAdaptedStudentSemester, JsonAdaptedTimeTable> toModelType() throws IllegalValueException {
+    public Pair<StudentSemester, TimeTable> toModelType() throws IllegalValueException {
         if (sem == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     StudentSemester.class.getSimpleName()));
@@ -52,6 +52,6 @@ public class JsonAdaptedTimeTablePair {
                     TimeTable.class.getSimpleName()));
         }
 
-        return new Pair<>(sem, timeTable);
+        return new Pair<>(sem.toModelType(), timeTable.toModelType());
     }
 }

--- a/src/main/java/seedu/planner/storage/JsonSerializablePlanner.java
+++ b/src/main/java/seedu/planner/storage/JsonSerializablePlanner.java
@@ -74,7 +74,6 @@ class JsonSerializablePlanner {
         }
 
         if (0 <= activeStudentIndex && activeStudentIndex < students.size()) {
-            // TODO: ensure `activeStudent.toModelType()` can be used in `Planner#activateStudent`
             JsonAdaptedStudent jsonActiveStudent = students.get(activeStudentIndex);
 
             Student activeStudent = planner.getEqualStudent(jsonActiveStudent.toModelType());

--- a/src/test/java/seedu/planner/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/planner/logic/commands/CommandTestUtil.java
@@ -23,7 +23,7 @@ public class CommandTestUtil {
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_DEGREE_YEAR = PREFIX_STUDENT_YEAR + "1";
-    public static final String VALID_SEMESTER = PREFIX_STUDENT_SEM + "SPECIAL_ONE";
+    public static final String VALID_SEMESTER = PREFIX_STUDENT_SEM + "st1";
     public static final String VALID_MAJOR_CS = "CS";
     public static final String VALID_MAJOR_CS_LOWER = "cs";
     public static final String VALID_MAJOR_IS = "IS";


### PR DESCRIPTION
"ONE", "TWO", "SPECIAL_ONE" and "SPECIAL_TWO" are now rejected by `ParserUtil` (and hence all `timetable` commands), following recent changes of semester syntax.

Fixed crashes due to some invalid JSON in save file.
Improved robustness and handling of invalid JSON in save file.

Handle invalid module codes for enrollments and exemption list in JSON save file when converting to model classes.